### PR TITLE
Rebuild V0 register support from the official Sydpower protocol spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ __pycache__
 # misc
 .coverage
 .vscode
+.claude-flow
+# packaged release artifacts — HACS builds these from the tag, not the tree
+custom_components/*.zip
 coverage.xml
 .ruff_cache
 *.code-workspace

--- a/custom_components/fossibot-ha/__init__.py
+++ b/custom_components/fossibot-ha/__init__.py
@@ -13,7 +13,13 @@ from .coordinator import FossibotDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.SELECT, Platform.NUMBER]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.SELECT,
+    Platform.NUMBER,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/fossibot-ha/binary_sensor.py
+++ b/custom_components/fossibot-ha/binary_sensor.py
@@ -1,0 +1,182 @@
+"""Support for Fossibot binary sensors.
+
+These expose the 32-bit system-state field (input registers 41 + 42,
+appendix &*8) and the aggregated fault state. Before this platform existed
+only four of the thirty-two state bits were reachable, and register 42 —
+the whole low half, carrying the per-port and grid-presence flags — was
+never read at all.
+"""
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import FossibotDataUpdateCoordinator
+from .entity import FossibotEntity
+
+DIAGNOSTIC = EntityCategory.DIAGNOSTIC
+
+# (name, data key, device_class, entity_category, default_enabled)
+BINARY_SENSOR_DEFINITIONS = [
+    # --- Charging sources (bits 30..19) ----------------------------------
+    {"name": "Grid Charging", "key": "gridCharging",
+     "device_class": BinarySensorDeviceClass.BATTERY_CHARGING},  # bit 20
+    # Bit 19 is "AC input voltage presence"; bit 17 is the device's
+    # on-grid/off-grid determination. They are not the same thing — mains can
+    # be present while the unit runs off-grid.
+    {"name": "Grid Input Present", "key": "gridVoltagePresent",
+     "device_class": BinarySensorDeviceClass.PLUG},  # bit 19
+    {"name": "On Grid", "key": "gridConnected"},  # bit 17
+    {"name": "DC Charging", "key": "dcCharging",
+     "device_class": BinarySensorDeviceClass.BATTERY_CHARGING},  # bit 22
+    {"name": "DC Input Present", "key": "dcChargeVoltagePresent",
+     "device_class": BinarySensorDeviceClass.PLUG},  # bit 21
+    {"name": "PV High Voltage Charging", "key": "pvHighVoltageCharging",
+     "device_class": BinarySensorDeviceClass.BATTERY_CHARGING,
+     "default_enabled": False},  # bit 31
+    {"name": "PV High Voltage Present", "key": "pvHighVoltagePresent",
+     "device_class": BinarySensorDeviceClass.PLUG,
+     "default_enabled": False},  # bit 30
+    {"name": "Car Charging", "key": "carCharging",
+     "device_class": BinarySensorDeviceClass.BATTERY_CHARGING,
+     "default_enabled": False},  # bit 29
+    {"name": "Car Charge Input Present", "key": "carChargeVoltagePresent",
+     "device_class": BinarySensorDeviceClass.PLUG,
+     "default_enabled": False},  # bit 24
+
+    # --- Output state ----------------------------------------------------
+    {"name": "AC Inverter Output", "key": "acInverterOutput",
+     "device_class": BinarySensorDeviceClass.POWER},  # bit 18
+    {"name": "DC Port Output", "key": "dcPortOutput",
+     "device_class": BinarySensorDeviceClass.POWER},  # bit 23
+    {"name": "Wireless Charging Active", "key": "wirelessCharging",
+     "device_class": BinarySensorDeviceClass.POWER,
+     "default_enabled": False},  # bit 16
+    {"name": "ECO Mode", "key": "ecoMode"},  # bit 12
+    # The LED button's on/off bit. The LED Mode select already reports the
+    # richer four-state mode, so this stays off by default.
+    {"name": "LED Output", "key": "ledOutput",
+     "device_class": BinarySensorDeviceClass.POWER,
+     "default_enabled": False},  # bit 28
+
+    # --- Individual ports (off by default) -------------------------------
+    {"name": "XT60 Port", "key": "portXt60Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 13
+    {"name": "Cigarette Socket", "key": "portCigaretteOutput",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 14
+    {"name": "DC 5521 Port", "key": "port5521Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 15
+    {"name": "USB 1 Port", "key": "usb1Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 0
+    {"name": "USB 2 Port", "key": "usb2Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 1
+    {"name": "QC 1 Port", "key": "qc1Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 3
+    {"name": "QC 2 Port", "key": "qc2Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 4
+    {"name": "PD 1 Port", "key": "pd1Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 6
+    {"name": "PD 2 Port", "key": "pd2Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 7
+    {"name": "PD 3 Port", "key": "pd3Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 8
+    {"name": "PD 4 Port", "key": "pd4Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 9
+    {"name": "PD 5 Port", "key": "pd5Output",
+     "device_class": BinarySensorDeviceClass.POWER, "default_enabled": False},  # bit 10
+
+    # --- Battery state (BMS words, informational bits) -------------------
+    {"name": "Battery Charging", "key": "charging",
+     "device_class": BinarySensorDeviceClass.BATTERY_CHARGING,
+     "category": DIAGNOSTIC},  # input 48 bit 15
+    {"name": "Battery Discharging", "key": "discharging",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 48 bit 14
+    {"name": "Battery Fully Charged", "key": "fullyCharged",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 48 bit 12
+    {"name": "Battery Fully Discharged", "key": "fullyDischarged",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 48 bit 13
+    {"name": "Battery Overvoltage", "key": "batteryOvervoltage",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 48 bit 7
+    {"name": "Battery Balancing", "key": "balancing",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 48 bit 6
+    {"name": "Precharge MOSFET On", "key": "prechargeMosfetOn",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 47 bit 14
+    {"name": "Charge MOSFET On", "key": "chargeMosfetOn",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 47 bit 13
+    {"name": "Discharge MOSFET On", "key": "dischargeMosfetOn",
+     "category": DIAGNOSTIC, "default_enabled": False},  # input 47 bit 12
+
+    # --- Faults ----------------------------------------------------------
+    {"name": "Fault", "key": "hasFault",
+     "device_class": BinarySensorDeviceClass.PROBLEM,
+     "category": DIAGNOSTIC, "attribute_keys": (
+         "faults", "faultsAc", "faultsPv", "faultsBms", "faultsPanel")},
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Fossibot binary sensors."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = [
+        FossibotBinarySensor(coordinator, device_id, **defn)
+        for device_id in coordinator.data
+        for defn in BINARY_SENSOR_DEFINITIONS
+    ]
+
+    async_add_entities(entities)
+
+
+class FossibotBinarySensor(FossibotEntity, BinarySensorEntity):
+    """A single bit of the Fossibot system-state or fault field."""
+
+    def __init__(
+        self,
+        coordinator: FossibotDataUpdateCoordinator,
+        device_id: str,
+        name: str,
+        key: str,
+        device_class: BinarySensorDeviceClass | None = None,
+        category: EntityCategory | None = None,
+        default_enabled: bool = True,
+        attribute_keys: tuple[str, ...] = (),
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator, device_id)
+        self._key = key
+        self._attribute_keys = attribute_keys
+        self._attr_name = f"Fossibot {device_id} {name}"
+        self._attr_unique_id = f"{device_id}_{key}"
+        self._attr_device_class = device_class
+        self._attr_entity_category = category
+        self._attr_entity_registry_enabled_default = default_enabled
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the state of the bit."""
+        if self._device_id not in self.coordinator.data:
+            return None
+        return self.coordinator.data[self._device_id].get(self._key)
+
+    @property
+    def extra_state_attributes(self):
+        """Expose the decoded fault names behind an aggregate sensor."""
+        if not self._attribute_keys:
+            return None
+        device_data = self.coordinator.data.get(self._device_id, {})
+        attributes = {
+            key: device_data[key]
+            for key in self._attribute_keys
+            if key in device_data
+        }
+        return attributes or None

--- a/custom_components/fossibot-ha/entity.py
+++ b/custom_components/fossibot-ha/entity.py
@@ -4,6 +4,17 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
 
+# Board version registers (holding 47..51). Each packs a hardware and a
+# software version into one word, so each board contributes to both of Home
+# Assistant's version fields.
+_VERSION_FIELDS = (
+    ("AC", "versionAc"),
+    ("BMS", "versionBms"),
+    ("PV", "versionPv"),
+    ("Panel", "versionPanel"),
+    ("Com", "versionExternalCom"),
+)
+
 
 class FossibotEntity(CoordinatorEntity):
     """Base class for all Fossibot entities.
@@ -25,12 +36,53 @@ class FossibotEntity(CoordinatorEntity):
 
     @property
     def device_info(self):
-        """Return device information."""
-        # Use device_name from API if available
+        """Return device information.
+
+        Model, firmware and serial number come from the holding registers the
+        protocol reserves for them (11 device type/model, 47-51 board
+        versions, 72-79 serial number), so the device page shows real
+        hardware detail rather than just a MAC address.
+        """
         device_data = self.coordinator.data.get(self._device_id, {})
         name = device_data.get("device_name") or f"Fossibot {self._device_id}"
-        return {
+
+        info = {
             "identifiers": {(DOMAIN, self._device_id)},
             "name": name,
             "manufacturer": MANUFACTURER,
         }
+
+        model = self._model(device_data)
+        if model:
+            info["model"] = model
+
+        for field, suffix in (("sw_version", "Software"),
+                              ("hw_version", "Hardware")):
+            versions = [
+                "%s %s" % (label, device_data["%s%s" % (key, suffix)])
+                for label, key in _VERSION_FIELDS
+                if device_data.get("%s%s" % (key, suffix)) is not None
+            ]
+            if versions:
+                info[field] = " / ".join(versions)
+
+        serial = device_data.get("serialNumber")
+        if serial:
+            info["serial_number"] = serial
+
+        return info
+
+    @staticmethod
+    def _model(device_data: dict) -> str | None:
+        """Build a model string from the API record or holding register 11."""
+        product_info = device_data.get("productInfo") or {}
+        for key in ("product_name", "model", "device_model"):
+            value = product_info.get(key)
+            if value:
+                return str(value)
+
+        market_type = device_data.get("deviceMarketType")
+        model_code = device_data.get("deviceModelCode")
+        if market_type and model_code:
+            return "%s (model %s)" % (market_type, model_code)
+        return market_type or None

--- a/custom_components/fossibot-ha/manifest.json
+++ b/custom_components/fossibot-ha/manifest.json
@@ -6,14 +6,14 @@
         "@iamslan"
     ],
     "config_flow": true,
-    "documentation": "https://github.com/iamslan/fossibot",
+    "documentation": "https://github.com/iamslan/ha-fossibot",
     "dependencies": [],
     "integration_type": "hub",
     "iot_class": "local_polling",
-    "issue_tracker": "https://github.com/iamslan/fossibot/issues",
+    "issue_tracker": "https://github.com/iamslan/ha-fossibot/issues",
     "requirements": [
         "paho-mqtt>=1.6.1",
         "aiohttp>=3.8.0"
     ],
-    "version": "2.1.1"
+    "version": "3.0.0"
 }

--- a/custom_components/fossibot-ha/number.py
+++ b/custom_components/fossibot-ha/number.py
@@ -4,24 +4,46 @@ import logging
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import FossibotDataUpdateCoordinator
 from .entity import FossibotEntity
+from .sydpower.modbus import NOT_SET, pack_byte_pair
 from .sydpower.const import (
+    HREG_LOW_BATTERY_NOTIFY,
+    HREG_WIFI_UPLOAD_INTERVAL,
+    REGISTER_CHARGING_LIMIT,
+    REGISTER_DISCHARGE_LIMIT,
     REGISTER_MAXIMUM_CHARGING_CURRENT,
     REGISTER_STOP_CHARGE_AFTER,
-    REGISTER_DISCHARGE_LIMIT,
-    REGISTER_CHARGING_LIMIT,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Number definitions
+#
+# ``min_value``/``max_value`` are in the entity's display unit; ``multiplier``
+# converts that to the raw register value. Ranges follow the Sydpower
+# "Modbus RTU Protocol" (Inverter-Protocol-V0) section 3.1 exactly:
+#
+#   holding 20 — DC charging current, 1 A/count, "< DC Input Max Curr" (h17)
+#   holding 63 — AC scheduled charge time, 1 min/count, "Range: 1~5000"
+#   holding 66 — minimum discharge SOC, 0.1%/count, "Range: 0~500"   → 0-50%
+#   holding 67 — maximum charge SOC,    0.1%/count, "Range: 600~1000" → 60-100%
+#   holding 54 — Wi-Fi upload interval, 1 s/count
+#   holding 69 — low-battery notification threshold, 1%/count, 0~100
+# ---------------------------------------------------------------------------
+
 NUMBER_DEFINITIONS = [
     {
-        "name": "Maximum Charging Current",
+        # Register 20 is the *DC* (PV / vehicle) charging current limit, not
+        # the AC one. It was previously presented as "Maximum Charging
+        # Current" and documented as an AC limit, which is wrong.
+        "name": "DC Input Charging Current Limit",
         "key": "maximumChargingCurrent",
         "register": REGISTER_MAXIMUM_CHARGING_CURRENT,
         "min_value": 1,
@@ -30,13 +52,15 @@ NUMBER_DEFINITIONS = [
         "unit": "A",
         "mode": NumberMode.SLIDER,
         "multiplier": 1,
+        # Narrow the slider to what this device says it supports (holding 17).
+        "max_from_key": "dcInputMaxCurrent",
     },
     {
         "name": "Stop Charge After",
         "key": "stopChargeAfter",
         "register": REGISTER_STOP_CHARGE_AFTER,
         "min_value": 0,
-        "max_value": 1440,
+        "max_value": 5000,
         "step": 1,
         "unit": "min",
         "mode": NumberMode.BOX,
@@ -47,22 +71,49 @@ NUMBER_DEFINITIONS = [
         "key": "dischargeLowerLimit",
         "register": REGISTER_DISCHARGE_LIMIT,
         "min_value": 0,
-        "max_value": 100,
+        "max_value": 50,     # protocol: register range 0~500 at 0.1%/count
         "step": 1,
         "unit": "%",
         "mode": NumberMode.SLIDER,
-        "multiplier": 10,  # UI shows %, register stores permille
+        "multiplier": 10,    # UI shows %, register stores permille
     },
     {
         "name": "AC Charging Upper Limit",
         "key": "acChargingUpperLimit",
         "register": REGISTER_CHARGING_LIMIT,
+        "min_value": 60,     # protocol: register range 600~1000 at 0.1%/count
+        "max_value": 100,
+        "step": 1,
+        "unit": "%",
+        "mode": NumberMode.SLIDER,
+        "multiplier": 10,    # UI shows %, register stores permille
+    },
+    {
+        "name": "Wi-Fi Upload Interval",
+        "key": "wifiUploadInterval",
+        "register": HREG_WIFI_UPLOAD_INTERVAL,
+        "min_value": 5,
+        "max_value": 3600,
+        "step": 1,
+        "unit": "s",
+        "mode": NumberMode.BOX,
+        "multiplier": 1,
+        "category": EntityCategory.CONFIG,
+    },
+    {
+        "name": "Low Battery Notification Threshold",
+        "key": "lowBatteryNotifyThreshold",
+        "register": HREG_LOW_BATTERY_NOTIFY,
         "min_value": 0,
         "max_value": 100,
         "step": 1,
         "unit": "%",
         "mode": NumberMode.SLIDER,
-        "multiplier": 10,  # UI shows %, register stores permille
+        "multiplier": 1,
+        "category": EntityCategory.CONFIG,
+        # Register 69 also holds the notification enable flag in its high
+        # byte; write 0xFF there so the enable state is left untouched.
+        "pack_high": NOT_SET,
     },
 ]
 
@@ -100,19 +151,25 @@ class FossibotNumber(FossibotEntity, NumberEntity):
         unit: str,
         mode: NumberMode,
         multiplier: int,
+        category: EntityCategory | None = None,
+        max_from_key: str | None = None,
+        pack_high: int | None = None,
     ) -> None:
         """Initialize the number entity."""
         super().__init__(coordinator, device_id)
         self._key = key
         self._register = register
         self._multiplier = multiplier
+        self._max_from_key = max_from_key
+        self._pack_high = pack_high
+        self._declared_max = max_value
         self._attr_name = f"Fossibot {device_id} {name}"
         self._attr_unique_id = f"{device_id}_{key}"
         self._attr_native_min_value = min_value
-        self._attr_native_max_value = max_value
         self._attr_native_step = step
         self._attr_native_unit_of_measurement = unit
         self._attr_mode = mode
+        self._attr_entity_category = category
 
     @property
     def native_value(self):
@@ -121,9 +178,25 @@ class FossibotNumber(FossibotEntity, NumberEntity):
             return None
         return self.coordinator.data[self._device_id].get(self._key)
 
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum, narrowed by the device's own reported limit."""
+        if not self._max_from_key:
+            return self._declared_max
+
+        reported = self.coordinator.data.get(self._device_id, {}).get(
+            self._max_from_key
+        )
+        if not isinstance(reported, (int, float)) or reported <= 0:
+            return self._declared_max
+        return min(self._declared_max, float(reported))
+
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""
-        reg_value = int(value * self._multiplier)
+        reg_value = int(round(value * self._multiplier))
+        if self._pack_high is not None:
+            reg_value = pack_byte_pair(self._pack_high, reg_value)
+
         await self.coordinator.connector.run_command(
             self._device_id, "write_register", (self._register, reg_value)
         )

--- a/custom_components/fossibot-ha/select.py
+++ b/custom_components/fossibot-ha/select.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -12,32 +13,60 @@ from .const import DOMAIN
 from .coordinator import FossibotDataUpdateCoordinator
 from .entity import FossibotEntity
 from .sydpower.const import (
-    REGISTER_USB_STANDBY_TIME,
+    HREG_AC_CHARGE_LEVEL,
+    HREG_DC_INPUT_TYPE,
     REGISTER_AC_STANDBY_TIME,
     REGISTER_DC_STANDBY_TIME,
+    REGISTER_LED,
     REGISTER_SCREEN_REST_TIME,
     REGISTER_SLEEP_TIME,
+    REGISTER_USB_STANDBY_TIME,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# LED mode (command-based: uses pre-defined COMMANDS in connector)
-# ---------------------------------------------------------------------------
-
-LED_MODES = {
-    "Off": "REGDisableLED",
-    "On": "REGEnableLEDAlways",
-    "SOS": "REGEnableLEDSOS",
-    "Flash": "REGEnableLEDFlash",
-}
-
-# ---------------------------------------------------------------------------
-# Register-based selects: each maps display labels → raw register values
-# Uses OrderedDict so HA UI shows options in a logical order.
+# Register-based selects: each maps display labels → raw register values.
+#
+# ``key`` names the field the decoder writes the *current* value into. For
+# most selects that is the same holding register being written; the LED mode
+# is the exception — it is set through holding 27 but reported back through
+# input register 25 ("LightMode"), which is why the previous implementation
+# had to guess the active mode and could never show SOS or Flash.
+#
+# OrderedDict keeps the HA dropdown in a sensible order.
 # ---------------------------------------------------------------------------
 
 SELECT_DEFINITIONS = [
+    {
+        "name": "LED Mode",
+        "key": "lightModeRaw",
+        "register": REGISTER_LED,
+        "unique_id_suffix": "led_mode",
+        "options": OrderedDict([
+            ("Off", 0), ("On", 1), ("SOS", 2), ("Flash", 3),
+        ]),
+    },
+    {
+        "name": "AC Charging Rate",
+        "key": "acChargingRate",
+        "register": HREG_AC_CHARGE_LEVEL,
+        "unique_id_suffix": "ac_charge_level",
+        "options": OrderedDict([
+            ("Level 1", 1), ("Level 2", 2), ("Level 3", 3),
+            ("Level 4", 4), ("Level 5", 5),
+        ]),
+    },
+    {
+        "name": "DC Input Type",
+        "key": "dcInputTypeRaw",
+        "register": HREG_DC_INPUT_TYPE,
+        "unique_id_suffix": "dc_input_type",
+        "category": EntityCategory.CONFIG,
+        "options": OrderedDict([
+            ("MPPT (PV)", 0), ("DC source", 1),
+        ]),
+    },
     {
         "name": "USB Standby Time",
         "key": "usbStandbyTime",
@@ -89,70 +118,14 @@ async def async_setup_entry(
     """Set up Fossibot select entities."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities = []
-    for device_id in coordinator.data:
-        entities.append(FossibotLEDModeSelect(coordinator, device_id))
-        for defn in SELECT_DEFINITIONS:
-            entities.append(FossibotRegisterSelect(coordinator, device_id, **defn))
+    entities = [
+        FossibotRegisterSelect(coordinator, device_id, **defn)
+        for device_id in coordinator.data
+        for defn in SELECT_DEFINITIONS
+    ]
 
     async_add_entities(entities)
 
-
-# ---------------------------------------------------------------------------
-# LED mode select (command-based)
-# ---------------------------------------------------------------------------
-
-class FossibotLEDModeSelect(FossibotEntity, SelectEntity):
-    """Fossibot LED mode selector."""
-
-    def __init__(
-        self,
-        coordinator: FossibotDataUpdateCoordinator,
-        device_id: str,
-    ) -> None:
-        """Initialize the LED mode selector."""
-        super().__init__(coordinator, device_id)
-        self._key = "ledOutput"
-        self._attr_name = f"Fossibot {device_id} LED Mode"
-        self._attr_unique_id = f"{device_id}_led_mode"
-        self._attr_options = list(LED_MODES.keys())
-        self._last_selected_mode = "Off"
-
-    @property
-    def current_option(self):
-        """Return the currently selected LED mode."""
-        if self._device_id not in self.coordinator.data:
-            return None
-
-        led_state = self.coordinator.data[self._device_id].get(self._key, False)
-
-        if not led_state:
-            self._last_selected_mode = "Off"
-            return "Off"
-
-        # If LED is on but was previously off, assume "On" mode
-        if self._last_selected_mode == "Off":
-            self._last_selected_mode = "On"
-
-        return self._last_selected_mode
-
-    async def async_select_option(self, option: str) -> None:
-        """Change the selected option."""
-        if option not in LED_MODES:
-            _LOGGER.error("Invalid LED mode: %s", option)
-            return
-
-        self._last_selected_mode = option
-
-        await self.coordinator.connector.run_command(
-            self._device_id, LED_MODES[option]
-        )
-        await self.coordinator.async_request_refresh()
-
-
-# ---------------------------------------------------------------------------
-# Register-based select (write_register command)
-# ---------------------------------------------------------------------------
 
 class FossibotRegisterSelect(FossibotEntity, SelectEntity):
     """Fossibot select backed by a Modbus register with discrete allowed values."""
@@ -165,6 +138,8 @@ class FossibotRegisterSelect(FossibotEntity, SelectEntity):
         key: str,
         register: int,
         options: OrderedDict,
+        unique_id_suffix: str | None = None,
+        category: EntityCategory | None = None,
     ) -> None:
         """Initialize the register-based select."""
         super().__init__(coordinator, device_id)
@@ -173,8 +148,9 @@ class FossibotRegisterSelect(FossibotEntity, SelectEntity):
         self._options_map = options                        # label → register value
         self._reverse_map = {v: k for k, v in options.items()}  # register value → label
         self._attr_name = f"Fossibot {device_id} {name}"
-        self._attr_unique_id = f"{device_id}_{key}"
+        self._attr_unique_id = f"{device_id}_{unique_id_suffix or key}"
         self._attr_options = list(options.keys())
+        self._attr_entity_category = category
 
     @property
     def current_option(self):

--- a/custom_components/fossibot-ha/sensor.py
+++ b/custom_components/fossibot-ha/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -13,18 +14,141 @@ from .const import DOMAIN
 from .coordinator import FossibotDataUpdateCoordinator
 from .entity import FossibotEntity
 
+# ---------------------------------------------------------------------------
+# Sensor definitions
+#
+# Every entry maps to a register documented in the Sydpower "Modbus RTU
+# Protocol" (Inverter-Protocol-V0), noted as "input NN" / "holding NN".
+#
+# ``default_enabled: False`` keeps per-port breakdowns out of the way — they
+# are useful for diagnosing a specific socket but would otherwise add two
+# dozen mostly-zero entities per device. Users can enable them individually.
+# ---------------------------------------------------------------------------
+
+POWER = SensorDeviceClass.POWER
+ENERGY = SensorDeviceClass.ENERGY
+VOLTAGE = SensorDeviceClass.VOLTAGE
+FREQUENCY = SensorDeviceClass.FREQUENCY
+BATTERY = SensorDeviceClass.BATTERY
+DURATION = SensorDeviceClass.DURATION
+DIAGNOSTIC = EntityCategory.DIAGNOSTIC
+
 SENSOR_DEFINITIONS = [
-    {"name": "State of Charge", "key": "soc", "unit": "%", "device_class": SensorDeviceClass.BATTERY},
-    {"name": "State of Charge Slave 1", "key": "soc_s1", "unit": "%", "device_class": SensorDeviceClass.BATTERY},
-    {"name": "State of Charge Slave 2", "key": "soc_s2", "unit": "%", "device_class": SensorDeviceClass.BATTERY},
-    {"name": "DC Input", "key": "dcInput", "unit": "W", "device_class": SensorDeviceClass.POWER},
-    {"name": "Total Input", "key": "totalInput", "unit": "W", "device_class": SensorDeviceClass.POWER},
-    {"name": "AC Charging Rate", "key": "acChargingRate", "unit": None, "device_class": None},
-    {"name": "Total Output", "key": "totalOutput", "unit": "W", "device_class": SensorDeviceClass.POWER},
-    {"name": "AC Output Voltage", "key": "acOutputVoltage", "unit": "V", "device_class": SensorDeviceClass.VOLTAGE},
-    {"name": "AC Output Frequency", "key": "acOutputFrequency", "unit": "Hz", "device_class": SensorDeviceClass.FREQUENCY},
-    {"name": "AC Input Voltage", "key": "acInputVoltage", "unit": "V", "device_class": SensorDeviceClass.VOLTAGE},
-    {"name": "AC Input Frequency", "key": "acInputFrequency", "unit": "Hz", "device_class": SensorDeviceClass.FREQUENCY},
+    # --- Battery ---------------------------------------------------------
+    {"name": "State of Charge", "key": "soc", "unit": "%", "device_class": BATTERY},  # input 56
+    {"name": "State of Charge Slave 1", "key": "soc_s1", "unit": "%", "device_class": BATTERY},  # input 53
+    {"name": "State of Charge Slave 2", "key": "soc_s2", "unit": "%", "device_class": BATTERY},  # input 55
+    {"name": "State of Charge Slave 3", "key": "soc_s3", "unit": "%", "device_class": BATTERY},  # input 66
+    {"name": "State of Charge Slave 4", "key": "soc_s4", "unit": "%", "device_class": BATTERY},  # input 67
+    {"name": "Battery Usable Capacity", "key": "batteryUsableCapacity", "unit": "Ah",
+     "state_class": SensorStateClass.MEASUREMENT},  # input 54
+    {"name": "Average Discharge SoC", "key": "averageDischargeSoc", "unit": "%",
+     "state_class": SensorStateClass.MEASUREMENT, "category": DIAGNOSTIC},  # input 70
+    {"name": "Average Charge SoC", "key": "averageChargeSoc", "unit": "%",
+     "state_class": SensorStateClass.MEASUREMENT, "category": DIAGNOSTIC},  # input 71
+
+    # --- Input power -----------------------------------------------------
+    {"name": "AC Input", "key": "acInput", "unit": "W", "device_class": POWER},  # input 03
+    {"name": "DC Input", "key": "dcInput", "unit": "W", "device_class": POWER},  # input 04
+    {"name": "USB-C Input", "key": "typecInput", "unit": "W", "device_class": POWER},  # input 05
+    {"name": "Total Input", "key": "totalInput", "unit": "W", "device_class": POWER},  # input 06
+
+    # --- Output power ----------------------------------------------------
+    {"name": "Total Output", "key": "totalOutput", "unit": "W", "device_class": POWER},  # input 39
+    {"name": "AC Output Power", "key": "acOutputPower", "unit": "W", "device_class": POWER},  # input 20
+    {"name": "Inverter Output Power", "key": "inverterOutputPower", "unit": "W",
+     "device_class": POWER},  # input 16
+    {"name": "Inverter Apparent Power", "key": "inverterOutputApparentPower", "unit": "VA",
+     "device_class": SensorDeviceClass.APPARENT_POWER, "default_enabled": False},  # input 17
+
+    # --- AC electrical ---------------------------------------------------
+    {"name": "AC Output Voltage", "key": "acOutputVoltage", "unit": "V", "device_class": VOLTAGE},  # input 18
+    {"name": "AC Output Frequency", "key": "acOutputFrequency", "unit": "Hz", "device_class": FREQUENCY},  # input 19
+    {"name": "AC Input Voltage", "key": "acInputVoltage", "unit": "V", "device_class": VOLTAGE},  # input 21
+    {"name": "AC Input Frequency", "key": "acInputFrequency", "unit": "Hz", "device_class": FREQUENCY},  # input 22
+
+    # --- Energy ----------------------------------------------------------
+    # Input 60 is offset by one so that 0 can mean "no counter fitted"; the
+    # decoder removes the offset, so the sensor is a true lifetime total.
+    {"name": "PV Energy Total", "key": "pvEnergyTotal", "unit": "kWh", "device_class": ENERGY,
+     "state_class": SensorStateClass.TOTAL_INCREASING},  # input 60
+
+    # --- Timers ----------------------------------------------------------
+    {"name": "Remaining Charge Time", "key": "remainingChargeTime", "unit": "min",
+     "device_class": DURATION, "state_class": SensorStateClass.MEASUREMENT},  # input 58
+    {"name": "Remaining Discharge Time", "key": "remainingDischargeTime", "unit": "min",
+     "device_class": DURATION, "state_class": SensorStateClass.MEASUREMENT},  # input 59
+    {"name": "Charge Schedule Remaining", "key": "chargeAppointmentRemaining", "unit": "min",
+     "device_class": DURATION, "state_class": SensorStateClass.MEASUREMENT,
+     "default_enabled": False},  # input 57
+
+    # --- Settings readback ----------------------------------------------
+    # The AC charge level, LED mode and DC input type are exposed as selects
+    # (which both report and set them), so they have no duplicate sensor.
+    # Input 02 is the level the device is *actually* running at, which can
+    # lag the holding-13 setting, so it gets its own diagnostic sensor.
+    {"name": "AC Charging Rate Active", "key": "acChargeLevelActive", "unit": None,
+     "device_class": None, "category": DIAGNOSTIC, "default_enabled": False},  # input 02
+
+    # --- Faults ----------------------------------------------------------
+    {"name": "Active Faults", "key": "faultCount", "unit": None, "device_class": None,
+     "category": DIAGNOSTIC, "attribute_keys": (
+         "faults", "faultsAc", "faultsPv", "faultsBms", "faultsPanel")},
+
+    # --- Device capability / identity (diagnostic) -----------------------
+    {"name": "AC Charge Max Power", "key": "acChargeMaxPower", "unit": "W", "device_class": POWER,
+     "category": DIAGNOSTIC, "default_enabled": False},  # holding 14
+    {"name": "DC Input Max Power", "key": "dcInputMaxPower", "unit": "W", "device_class": POWER,
+     "category": DIAGNOSTIC, "default_enabled": False},  # holding 16
+    {"name": "DC Input Max Current", "key": "dcInputMaxCurrent", "unit": "A",
+     "device_class": SensorDeviceClass.CURRENT, "category": DIAGNOSTIC,
+     "default_enabled": False},  # holding 17
+    {"name": "Battery Chemistry", "key": "batteryChemistry", "unit": None, "device_class": None,
+     "category": DIAGNOSTIC, "default_enabled": False,
+     "attribute_keys": ("batteryCapacityAh", "batteryCellsSeries",
+                        "batteryCellsParallel")},  # holding 40/41
+    {"name": "Protocol Version", "key": "protocolVersion", "unit": None, "device_class": None,
+     "category": DIAGNOSTIC, "default_enabled": False},  # holding 5
+    {"name": "DC Input Min Voltage", "key": "dcInputMinVoltage", "unit": "V",
+     "device_class": VOLTAGE, "category": DIAGNOSTIC,
+     "default_enabled": False},  # holding 18
+    {"name": "DC Input Max Voltage", "key": "dcInputMaxVoltage", "unit": "V",
+     "device_class": VOLTAGE, "category": DIAGNOSTIC,
+     "default_enabled": False},  # holding 19
+
+    # --- Per-port power breakdown (off by default) -----------------------
+    {"name": "USB 1 Power", "key": "usb1Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 26
+    {"name": "USB 2 Power", "key": "usb2Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 27
+    {"name": "USB 3 Power", "key": "usb3Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 28
+    {"name": "QC 1 Power", "key": "qc1Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 30
+    {"name": "QC 2 Power", "key": "qc2Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 31
+    {"name": "QC 3 Power", "key": "qc3Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 32
+    {"name": "PD 1 Power", "key": "pd1Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 34
+    {"name": "PD 2 Power", "key": "pd2Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 35
+    {"name": "PD 3 Power", "key": "pd3Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 36
+    {"name": "PD 4 Power", "key": "pd4Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 37
+    {"name": "PD 5 Power", "key": "pd5Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 38
+    {"name": "XT60 Power", "key": "xt60Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 08
+    {"name": "Cigarette Socket Power", "key": "cigarettePower", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 09
+    {"name": "DC 5521 Power", "key": "port5521Power", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 10
+    {"name": "Wireless Charging Power", "key": "wirelessChargingPower", "unit": "W",
+     "device_class": POWER, "default_enabled": False},  # input 13
+    {"name": "LED Power", "key": "ledPower", "unit": "W", "device_class": POWER,
+     "default_enabled": False},  # input 15
 ]
 
 
@@ -56,16 +180,32 @@ class FossibotSensor(FossibotEntity, SensorEntity):
         key: str,
         unit: str | None,
         device_class: SensorDeviceClass | None,
+        state_class: SensorStateClass | None = None,
+        category: EntityCategory | None = None,
+        default_enabled: bool = True,
+        attribute_keys: tuple[str, ...] = (),
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, device_id)
         self._key = key
+        self._attribute_keys = attribute_keys
         self._attr_name = f"Fossibot {device_id} {name}"
         self._attr_native_unit_of_measurement = unit
         self._attr_device_class = device_class
         self._attr_unique_id = f"{device_id}_{key}"
+        self._attr_entity_category = category
+        self._attr_entity_registry_enabled_default = default_enabled
 
-        if device_class == SensorDeviceClass.POWER:
+        if state_class is not None:
+            self._attr_state_class = state_class
+        elif device_class in (
+            SensorDeviceClass.POWER,
+            SensorDeviceClass.APPARENT_POWER,
+            SensorDeviceClass.VOLTAGE,
+            SensorDeviceClass.FREQUENCY,
+            SensorDeviceClass.CURRENT,
+            SensorDeviceClass.BATTERY,
+        ):
             self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
@@ -74,3 +214,16 @@ class FossibotSensor(FossibotEntity, SensorEntity):
         if self._device_id not in self.coordinator.data:
             return None
         return self.coordinator.data[self._device_id].get(self._key)
+
+    @property
+    def extra_state_attributes(self):
+        """Expose the supporting registers this sensor summarises."""
+        if not self._attribute_keys:
+            return None
+        device_data = self.coordinator.data.get(self._device_id, {})
+        attributes = {
+            key: device_data[key]
+            for key in self._attribute_keys
+            if key in device_data
+        }
+        return attributes or None

--- a/custom_components/fossibot-ha/switch.py
+++ b/custom_components/fossibot-ha/switch.py
@@ -1,19 +1,70 @@
 """Support for Fossibot switches."""
 
+import logging
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import FossibotDataUpdateCoordinator
 from .entity import FossibotEntity
+from .sydpower.modbus import pack_byte_pair, NOT_SET
+from .sydpower.const import (
+    HREG_APP_CONTROL_SLEEP,
+    HREG_BUZZER,
+    HREG_GRID_AC_AUTO_OUTPUT,
+    HREG_LOW_BATTERY_NOTIFY,
+)
 
+_LOGGER = logging.getLogger(__name__)
+
+# Switches driven by a pre-encoded command constant in the connector.
 SWITCH_DEFINITIONS = [
     {"name": "USB Output", "key": "usbOutput", "on_command": "REGEnableUSBOutput", "off_command": "REGDisableUSBOutput"},
     {"name": "DC Output", "key": "dcOutput", "on_command": "REGEnableDCOutput", "off_command": "REGDisableDCOutput"},
     {"name": "AC Output", "key": "acOutput", "on_command": "REGEnableACOutput", "off_command": "REGDisableACOutput"},
     {"name": "AC Silent Charging", "key": "acSilentCharging", "on_command": "REGEnableACSilentChg", "off_command": "REGDisableACSilentChg"},
+]
+
+# Switches that write a register value directly.
+#
+# The low-battery notification enable (holding 69) shares its register with
+# the notification threshold, so each write sets the other half to 0xFF —
+# the protocol's "leave this item alone" marker.
+REGISTER_SWITCH_DEFINITIONS = [
+    {
+        "name": "Buzzer",
+        "key": "buzzerEnabled",
+        "register": HREG_BUZZER,
+        "on_value": 1,
+        "off_value": 0,
+    },
+    {
+        "name": "Grid Mode AC Auto Output",
+        "key": "gridAcAutoOutput",
+        "register": HREG_GRID_AC_AUTO_OUTPUT,
+        "on_value": 1,
+        "off_value": 0,
+    },
+    {
+        "name": "App Remote Shutdown",
+        "key": "appControlSleep",
+        "register": HREG_APP_CONTROL_SLEEP,
+        "on_value": 1,
+        "off_value": 0,
+        "category": EntityCategory.CONFIG,
+    },
+    {
+        "name": "Low Battery Notification",
+        "key": "lowBatteryNotifyEnabled",
+        "register": HREG_LOW_BATTERY_NOTIFY,
+        "on_value": pack_byte_pair(1, NOT_SET),
+        "off_value": pack_byte_pair(0, NOT_SET),
+        "category": EntityCategory.CONFIG,
+    },
 ]
 
 
@@ -25,17 +76,47 @@ async def async_setup_entry(
     """Set up the Fossibot switches."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities = [
-        FossibotSwitch(coordinator, device_id, **defn)
-        for device_id in coordinator.data
-        for defn in SWITCH_DEFINITIONS
-    ]
+    entities: list[SwitchEntity] = []
+    for device_id in coordinator.data:
+        entities.extend(
+            FossibotSwitch(coordinator, device_id, **defn)
+            for defn in SWITCH_DEFINITIONS
+        )
+        entities.extend(
+            FossibotRegisterSwitch(coordinator, device_id, **defn)
+            for defn in REGISTER_SWITCH_DEFINITIONS
+        )
 
     async_add_entities(entities)
 
 
-class FossibotSwitch(FossibotEntity, SwitchEntity):
-    """Representation of a Fossibot switch."""
+class _FossibotSwitchBase(FossibotEntity, SwitchEntity):
+    """Shared state handling for Fossibot switches."""
+
+    def __init__(
+        self,
+        coordinator: FossibotDataUpdateCoordinator,
+        device_id: str,
+        name: str,
+        key: str,
+        category: EntityCategory | None = None,
+    ) -> None:
+        super().__init__(coordinator, device_id)
+        self._key = key
+        self._attr_name = f"Fossibot {device_id} {name}"
+        self._attr_unique_id = f"{device_id}_{key}"
+        self._attr_entity_category = category
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        if self._device_id not in self.coordinator.data:
+            return None
+        return self.coordinator.data[self._device_id].get(self._key)
+
+
+class FossibotSwitch(_FossibotSwitchBase):
+    """A Fossibot switch backed by a pre-encoded connector command."""
 
     def __init__(
         self,
@@ -45,21 +126,12 @@ class FossibotSwitch(FossibotEntity, SwitchEntity):
         key: str,
         on_command: str,
         off_command: str,
+        category: EntityCategory | None = None,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator, device_id)
-        self._key = key
-        self._attr_name = f"Fossibot {device_id} {name}"
+        super().__init__(coordinator, device_id, name, key, category)
         self._on_command = on_command
         self._off_command = off_command
-        self._attr_unique_id = f"{device_id}_{key}"
-
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        if self._device_id not in self.coordinator.data:
-            return None
-        return self.coordinator.data[self._device_id].get(self._key)
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
@@ -74,3 +146,38 @@ class FossibotSwitch(FossibotEntity, SwitchEntity):
             self._device_id, self._off_command
         )
         await self.coordinator.async_request_refresh()
+
+
+class FossibotRegisterSwitch(_FossibotSwitchBase):
+    """A Fossibot switch that writes a holding register directly."""
+
+    def __init__(
+        self,
+        coordinator: FossibotDataUpdateCoordinator,
+        device_id: str,
+        name: str,
+        key: str,
+        register: int,
+        on_value: int,
+        off_value: int,
+        category: EntityCategory | None = None,
+    ) -> None:
+        """Initialize the register-backed switch."""
+        super().__init__(coordinator, device_id, name, key, category)
+        self._register = register
+        self._on_value = on_value
+        self._off_value = off_value
+
+    async def _write(self, value: int) -> None:
+        await self.coordinator.connector.run_command(
+            self._device_id, "write_register", (self._register, value)
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self._write(self._on_value)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self._write(self._off_value)

--- a/custom_components/fossibot-ha/sydpower/connector.py
+++ b/custom_components/fossibot-ha/sydpower/connector.py
@@ -15,7 +15,10 @@ from .modbus import (
     REGEnableACSilentChg, get_read_modbus, get_read_input_modbus,
     get_write_modbus, ModbusValidationError,
 )
-from .const import REGISTER_MODBUS_ADDRESS, DEFAULT_MQTT_PORT
+from .const import (
+    REGISTER_MODBUS_ADDRESS, REGISTER_MAXIMUM_CHARGING_CURRENT,
+    DEFAULT_MQTT_PORT, MODBUS_READ_COUNT, MODBUS_MAX_READ_COUNT,
+)
 
 COMMANDS = {
     "REGRequestSettings": REGRequestSettings,
@@ -411,7 +414,18 @@ class SydpowerConnector:
         modbus_addr = device_info.get(
             "_modbus_address", REGISTER_MODBUS_ADDRESS
         )
-        modbus_count = device_info.get("_modbus_count", 80)
+        modbus_count = device_info.get("_modbus_count", MODBUS_READ_COUNT)
+
+        # The protocol caps a single read at 100 words and requires the range
+        # to stay inside one 100-register block, so a larger count from the
+        # API would produce a request the device cannot answer.
+        if modbus_count > MODBUS_MAX_READ_COUNT:
+            self._logger.warning(
+                "API reported modbus_count=%d for %s, clamping to protocol "
+                "maximum of %d",
+                modbus_count, device_mac, MODBUS_MAX_READ_COUNT,
+            )
+            modbus_count = MODBUS_MAX_READ_COUNT
 
         if func == 3:
             # Send func 03 (holding registers)
@@ -475,6 +489,21 @@ class SydpowerConnector:
             modbus_addr = device_info.get(
                 "_modbus_address", REGISTER_MODBUS_ADDRESS
             )
+
+            # Holding 20 is bounded by holding 17 ("DC Input Max Curr"), which
+            # is device-specific and therefore cannot live in the static
+            # allowlist. Enforce it here as well as in the number entity, so
+            # a service call that bypasses the UI is still checked.
+            if register == REGISTER_MAXIMUM_CHARGING_CURRENT:
+                device_max = device_info.get("dcInputMaxCurrent")
+                if isinstance(device_max, int) and 0 < device_max < reg_value:
+                    self._logger.error(
+                        "Refused to write %d A to register %d: device reports "
+                        "a maximum DC charging current of %d A",
+                        reg_value, register, device_max,
+                    )
+                    return False
+
             try:
                 command_bytes = get_write_modbus(
                     modbus_addr, register, reg_value,

--- a/custom_components/fossibot-ha/sydpower/const.py
+++ b/custom_components/fossibot-ha/sydpower/const.py
@@ -1,4 +1,3 @@
-
 # New SYDPOWER Local MQTT API
 API_BASE_URL = "https://api.app.sydpower.com/http/router/client/device"
 API_GET_DEVICE_LIST = f"{API_BASE_URL}/saas.pub_getDeviceList"
@@ -7,24 +6,224 @@ API_UPDATE_MQTT_STATE = f"{API_BASE_URL}/saas.pub_updateMqttState"
 # Default MQTT port for local broker
 DEFAULT_MQTT_PORT = 1883
 
-# Register definitions
+# ---------------------------------------------------------------------------
+# Modbus framing
+#
+# Slave address 17 (0x11) matches the "Slave Address 11" example throughout
+# the Sydpower "Modbus RTU Protocol" document (Inverter-Protocol-V0).
+#
+# A device may override this via productInfo.modbus_address from the API.
+# ---------------------------------------------------------------------------
 REGISTER_MODBUS_ADDRESS = 17
-REGISTER_TOTAL_INPUT = 6
-REGISTER_DC_INPUT = 4
-REGISTER_MAXIMUM_CHARGING_CURRENT = 20
-REGISTER_USB_OUTPUT = 24
-REGISTER_DC_OUTPUT = 25
-REGISTER_AC_OUTPUT = 26
-REGISTER_LED = 27
-REGISTER_TOTAL_OUTPUT = 39
-REGISTER_ACTIVE_OUTPUT_LIST = 41
-REGISTER_STATE_OF_CHARGE = 56
-REGISTER_AC_SILENT_CHARGING = 57
-REGISTER_USB_STANDBY_TIME = 59
-REGISTER_AC_STANDBY_TIME = 60
-REGISTER_DC_STANDBY_TIME = 61
-REGISTER_SCREEN_REST_TIME = 62
-REGISTER_STOP_CHARGE_AFTER = 63
-REGISTER_DISCHARGE_LIMIT = 66
-REGISTER_CHARGING_LIMIT = 67
-REGISTER_SLEEP_TIME = 68
+
+# The protocol caps a single read at 100 words and requires the range to sit
+# inside one 100-register block ("0~99 or 200~299 are OK, but 40~139 is not").
+#
+# Every documented V0 register — holding 0..79 and input 0..71 — falls inside
+# the first 80 words, so an 80-word read covers the whole map. The read count
+# is deliberately left at 80 rather than raised to the 100-word maximum: it is
+# the count the devices are known to answer, and reading further buys nothing.
+MODBUS_READ_COUNT = 80
+MODBUS_MAX_READ_COUNT = 100
+
+# ---------------------------------------------------------------------------
+# Holding registers (function 03) — settings / device identity
+# Source: Inverter-Protocol-V0.docx section 3.1
+# ---------------------------------------------------------------------------
+HREG_FACTORY_RESET = 0
+HREG_DEBUG_MODE = 1
+HREG_CHIP_TYPE = 2
+HREG_VALUE_ADDRESS = 3
+HREG_TIMEZONE = 4
+HREG_PROTOCOL_VERSION = 5
+HREG_DEVICE_TYPE_MODEL = 11
+HREG_VOLTAGE_FREQ_TYPE = 12
+HREG_AC_CHARGE_LEVEL = 13
+HREG_AC_CHARGE_MAX_POWER = 14
+HREG_DC_INPUT_TYPE = 15
+HREG_DC_INPUT_MAX_POWER = 16
+HREG_DC_INPUT_MAX_CURRENT = 17
+HREG_DC_INPUT_MIN_VOLTAGE = 18
+HREG_DC_INPUT_MAX_VOLTAGE = 19
+HREG_DC_INPUT_CURRENT_SET = 20
+HREG_QC_USB_CODE = 21
+HREG_PD_LED_CODE = 22
+HREG_USB_KEY = 24
+HREG_DC_KEY = 25
+HREG_AC_KEY = 26
+HREG_LED_KEY = 27
+HREG_PORT_XT60 = 30
+HREG_PORT_CIGARETTE = 31
+HREG_PORT_5521 = 32
+HREG_WIRELESS_DISCHARGER = 35
+HREG_WIRELESS_COM = 37
+HREG_BATTERY_INFO = 40
+HREG_BATTERY_PACK_FRAME = 41
+HREG_FUNCTION_CODE_H = 44
+HREG_FUNCTION_CODE_L = 45
+HREG_VERSION_AC = 47
+HREG_VERSION_BMS = 48
+HREG_VERSION_PV = 49
+HREG_VERSION_PANEL = 50
+HREG_VERSION_EXTERNAL_COM = 51
+HREG_WIFI_UPLOAD_INTERVAL = 54
+HREG_BUZZER = 56
+HREG_SILENT_CHARGING = 57
+HREG_USB_SLEEP_TIME = 59
+HREG_AC_SLEEP_TIME = 60
+HREG_DC_SLEEP_TIME = 61
+HREG_LCD_DIM_TIME = 62
+HREG_AC_CHARGE_APPOINTMENT = 63
+HREG_APP_CONTROL_SLEEP = 64
+HREG_DISCHARGE_SOC_MIN = 66
+HREG_CHARGE_SOC_MAX = 67
+HREG_SHUTDOWN_WAIT_TIME = 68
+HREG_LOW_BATTERY_NOTIFY = 69
+HREG_GRID_AC_AUTO_OUTPUT = 70
+HREG_SERIAL_FIRST = 72
+HREG_SERIAL_LAST = 79
+
+# ---------------------------------------------------------------------------
+# Input registers (function 04) — live measurements / status
+# Source: Inverter-Protocol-V0.docx section 3.2
+# ---------------------------------------------------------------------------
+IREG_AC_CHARGE_LEVEL = 2
+IREG_AC_CHARGE_POWER = 3
+IREG_DC_CHARGE_POWER = 4
+IREG_TYPEC_CHARGE_POWER = 5
+IREG_TOTAL_CHARGE_POWER = 6
+IREG_XT60_POWER = 8
+IREG_CIGARETTE_POWER = 9
+IREG_5521_POWER = 10
+IREG_WIRELESS_POWER = 13
+IREG_STORAGE_FLAG = 14
+IREG_LED_POWER = 15
+IREG_INV_OUTPUT_POWER = 16
+IREG_INV_OUTPUT_VA = 17
+IREG_AC_OUTPUT_VOLTAGE = 18
+IREG_AC_OUTPUT_FREQUENCY = 19
+IREG_AC_OUTPUT_POWER = 20
+IREG_GRID_VOLTAGE = 21
+IREG_GRID_FREQUENCY = 22
+IREG_LIGHT_MODE = 25
+IREG_USB1_POWER = 26
+IREG_USB2_POWER = 27
+IREG_USB3_POWER = 28
+IREG_QC1_POWER = 30
+IREG_QC2_POWER = 31
+IREG_QC3_POWER = 32
+IREG_PD1_POWER = 34
+IREG_PD2_POWER = 35
+IREG_PD3_POWER = 36
+IREG_PD4_POWER = 37
+IREG_PD5_POWER = 38
+IREG_TOTAL_DISCHARGE_POWER = 39
+IREG_SYSTEM_STATE_H = 41
+IREG_SYSTEM_STATE_L = 42
+IREG_FAULT_AC = 43
+IREG_FAULT_AC_2 = 44
+IREG_FAULT_PV = 45
+IREG_FAULT_HIGH_PV = 46
+IREG_BMS_AFE_STATUS = 47
+IREG_BMS_USER_STATUS = 48
+IREG_FAULT_PANEL_H = 50
+IREG_FAULT_PANEL_L = 51
+IREG_SLAVE_BATTERY_1 = 53
+IREG_BATTERY_USABLE_CAPACITY = 54
+IREG_SLAVE_BATTERY_2 = 55
+IREG_BATTERY_SOC = 56
+IREG_CHARGE_APPOINTMENT_REMAINING = 57
+IREG_REMAINING_CHARGE_TIME = 58
+IREG_REMAINING_DISCHARGE_TIME = 59
+IREG_PV_ENERGY_TOTAL = 60
+IREG_SLAVE_BATTERY_3 = 66
+IREG_SLAVE_BATTERY_4 = 67
+IREG_DISCHARGE_SOC_AVG = 70
+IREG_CHARGE_SOC_AVG = 71
+
+# ---------------------------------------------------------------------------
+# Legacy aliases
+#
+# These names predate the protocol documentation and are referenced by
+# modbus.py, the entity platforms and the test-suite. They are kept so that
+# existing imports keep working; prefer the HREG_*/IREG_* names above, which
+# make the register group (holding vs input) explicit.
+# ---------------------------------------------------------------------------
+REGISTER_TOTAL_INPUT = IREG_TOTAL_CHARGE_POWER            # input 06
+REGISTER_DC_INPUT = IREG_DC_CHARGE_POWER                  # input 04
+REGISTER_TOTAL_OUTPUT = IREG_TOTAL_DISCHARGE_POWER        # input 39
+REGISTER_ACTIVE_OUTPUT_LIST = IREG_SYSTEM_STATE_H         # input 41
+REGISTER_STATE_OF_CHARGE = IREG_BATTERY_SOC               # input 56
+
+REGISTER_MAXIMUM_CHARGING_CURRENT = HREG_DC_INPUT_CURRENT_SET  # holding 20
+REGISTER_USB_OUTPUT = HREG_USB_KEY                        # holding 24
+REGISTER_DC_OUTPUT = HREG_DC_KEY                          # holding 25
+REGISTER_AC_OUTPUT = HREG_AC_KEY                          # holding 26
+REGISTER_LED = HREG_LED_KEY                               # holding 27
+REGISTER_AC_SILENT_CHARGING = HREG_SILENT_CHARGING        # holding 57
+REGISTER_USB_STANDBY_TIME = HREG_USB_SLEEP_TIME           # holding 59
+REGISTER_AC_STANDBY_TIME = HREG_AC_SLEEP_TIME             # holding 60
+REGISTER_DC_STANDBY_TIME = HREG_DC_SLEEP_TIME             # holding 61
+REGISTER_SCREEN_REST_TIME = HREG_LCD_DIM_TIME             # holding 62
+REGISTER_STOP_CHARGE_AFTER = HREG_AC_CHARGE_APPOINTMENT   # holding 63
+REGISTER_DISCHARGE_LIMIT = HREG_DISCHARGE_SOC_MIN         # holding 66
+REGISTER_CHARGING_LIMIT = HREG_CHARGE_SOC_MAX             # holding 67
+REGISTER_SLEEP_TIME = HREG_SHUTDOWN_WAIT_TIME             # holding 68
+
+# ---------------------------------------------------------------------------
+# Enumerations from the protocol appendix
+# ---------------------------------------------------------------------------
+
+# Holding 40, high byte
+BATTERY_TYPES = {
+    1: "Ternary lithium",
+    2: "LiFePO4",
+    3: "Lead acid",
+}
+
+# Holding 11, high byte (&*2 "Device Type")
+DEVICE_MARKET_TYPES = {
+    0: "Portable Power Station 110V",
+    1: "Portable Power Station 230V",
+}
+
+# Holding 15, low byte
+DC_INPUT_TYPES = {
+    0: "MPPT (PV)",
+    1: "DC source",
+}
+
+# Input 25, low byte
+LIGHT_MODES = {
+    0: "Off",
+    1: "On",
+    2: "SOS",
+    3: "Flash",
+}
+
+# Holding 12, bits 15..3 (&*3 "Voltage Type") — one bit per supported voltage
+VOLTAGE_TYPE_BITS = {
+    10: "110V",
+    9: "380V",
+    8: "230V",
+    7: "220V",
+    6: "240V",
+    5: "120V",
+    4: "200V",
+    3: "100V",
+}
+
+# Holding 12, bits 2..0 (&*3 "Freq Type")
+FREQ_TYPES = {
+    1: "50Hz",
+    2: "60Hz",
+}
+
+# Holding 37, low byte (&*6 "WireLess COM") — one bit per fitted radio
+WIRELESS_COM_BITS = {
+    4: "ZigBee",
+    3: "LoRa",
+    2: "GPRS",
+    1: "Bluetooth",
+    0: "Wi-Fi",
+}

--- a/custom_components/fossibot-ha/sydpower/modbus.py
+++ b/custom_components/fossibot-ha/sydpower/modbus.py
@@ -1,15 +1,24 @@
 # modbus.py
-"""
-Modbus command conversion functions for Fossibot devices.
+"""Modbus command conversion functions for Fossibot devices.
 
 SAFETY NOTE: Fossibot firmware does NOT validate register write values.
 Writing an out-of-range value can permanently brick a device.  Every write
 MUST go through ``get_write_modbus()``, which validates against the
 WRITABLE_REGISTERS allowlist before encoding.
+
+Allowed ranges are taken from the Sydpower "Modbus RTU Protocol" document
+(``Inverter-Protocol-V0.docx``) section 3.1. Where that document gives an
+explicit range, the allowlist matches it exactly; the few deviations are
+called out in comments with the reason.
 """
 
 from typing import Dict, FrozenSet, List, Union
+
+# Several register constants below are re-exported rather than used directly:
+# scripts/ and external tooling import them from this module, so they are kept
+# in the namespace even though this file does not reference them all.
 from .const import (
+    MODBUS_READ_COUNT,
     REGISTER_MODBUS_ADDRESS, REGISTER_TOTAL_INPUT, REGISTER_DC_INPUT,
     REGISTER_MAXIMUM_CHARGING_CURRENT, REGISTER_USB_OUTPUT, REGISTER_DC_OUTPUT,
     REGISTER_AC_OUTPUT, REGISTER_LED, REGISTER_TOTAL_OUTPUT,
@@ -18,7 +27,11 @@ from .const import (
     REGISTER_AC_STANDBY_TIME, REGISTER_DC_STANDBY_TIME,
     REGISTER_SCREEN_REST_TIME, REGISTER_STOP_CHARGE_AFTER,
     REGISTER_DISCHARGE_LIMIT, REGISTER_CHARGING_LIMIT, REGISTER_SLEEP_TIME,
+    HREG_AC_CHARGE_LEVEL, HREG_APP_CONTROL_SLEEP, HREG_BUZZER,
+    HREG_DC_INPUT_TYPE, HREG_GRID_AC_AUTO_OUTPUT, HREG_LOW_BATTERY_NOTIFY,
+    HREG_WIFI_UPLOAD_INTERVAL,
 )
+from .registers import decode_holding_registers, decode_input_registers
 
 
 # ---------------------------------------------------------------------------
@@ -26,45 +39,102 @@ from .const import (
 #
 # Each entry maps a register number to a frozenset of allowed integer values.
 # ``get_write_modbus()`` refuses to encode a value that is not in this set.
-#
-# Source: Fossibot BrightEMS app reverse engineering (possibleValues arrays).
-# Registers without possibleValues use bounded ranges with a safety margin.
 # ---------------------------------------------------------------------------
 
+# Register 69 packs two independent 8-bit settings into one word:
+#   high byte = low-battery notification enable (0 or 1)
+#   low byte  = notification threshold in percent (0..100)
+# Writing 0xFF into either byte tells the device to leave that half alone,
+# which is how a single 16-bit write can change one setting in isolation.
+NOT_SET = 0xFF
+_LOW_BATTERY_VALUES = frozenset(
+    (enable << 8) | threshold
+    for enable in (0, 1, NOT_SET)
+    for threshold in list(range(0, 101)) + [NOT_SET]
+)
+
 WRITABLE_REGISTERS: Dict[int, FrozenSet[int]] = {
-    # Charging current: 1-20 A
+    # Holding 13 — AC charge power level. Protocol: "Range: 1-5".
+    HREG_AC_CHARGE_LEVEL: frozenset(range(1, 6)),
+
+    # Holding 15 — DC input type. Protocol: "0:MPPT 1:DC source".
+    HREG_DC_INPUT_TYPE: frozenset({0, 1}),
+
+    # Holding 20 — DC (PV / vehicle) charging current limit, 1 A per count.
+    # The protocol constrains this to "< DC Input Max Curr" (holding 17)
+    # rather than an absolute maximum, so the allowlist keeps a conservative
+    # 20 A ceiling and the number entity narrows it further using the value
+    # the device reports in holding 17.
     REGISTER_MAXIMUM_CHARGING_CURRENT: frozenset(range(1, 21)),
 
-    # Boolean outputs: 0 = off, 1 = on
+    # Holding 24/25/26 — USB / DC / AC output button state.
     REGISTER_USB_OUTPUT: frozenset({0, 1}),
     REGISTER_DC_OUTPUT: frozenset({0, 1}),
     REGISTER_AC_OUTPUT: frozenset({0, 1}),
 
-    # LED mode: 0=Off, 1=On, 2=SOS, 3=Flash
+    # Holding 27 — LED button. Modes per input register 25:
+    # 0=Off, 1=steady, 2=SOS, 3=strobe.
     REGISTER_LED: frozenset({0, 1, 2, 3}),
 
-    # AC silent charging: 0=off, 1=on
+    # Holding 54 — Wi-Fi automatic upload interval, 1 s per count.
+    # The protocol documents the unit but no range; bounded here to
+    # 5 s..1 h, comfortably inside any plausible firmware limit.
+    HREG_WIFI_UPLOAD_INTERVAL: frozenset(range(5, 3601)),
+
+    # Holding 56 — buzzer enable. Protocol: "Range: 0 and 1".
+    HREG_BUZZER: frozenset({0, 1}),
+
+    # Holding 57 — silent charging mode. Protocol: "Range: 0 and 1".
     REGISTER_AC_SILENT_CHARGING: frozenset({0, 1}),
 
-    # Standby timers (minutes)
-    REGISTER_USB_STANDBY_TIME: frozenset({0, 3, 5, 10, 30}),
-    REGISTER_AC_STANDBY_TIME: frozenset({0, 480, 960, 1440}),
-    REGISTER_DC_STANDBY_TIME: frozenset({0, 480, 960, 1440}),
+    # Holding 59/60/61 — no-load sleep timers, 1 min per count.
+    # Protocol: "Range: 1~5000 (0:no sleep)".
+    REGISTER_USB_STANDBY_TIME: frozenset(range(0, 5001)),
+    REGISTER_AC_STANDBY_TIME: frozenset(range(0, 5001)),
+    REGISTER_DC_STANDBY_TIME: frozenset(range(0, 5001)),
 
-    # Screen rest time (seconds)
-    REGISTER_SCREEN_REST_TIME: frozenset({0, 180, 300, 600, 1800}),
+    # Holding 62 — screen dim time, 1 s per count. Protocol: "Range: 1~5000".
+    # 0 is additionally allowed because the vendor app itself offers an "off"
+    # option for this setting, which is evidence the firmware accepts it.
+    REGISTER_SCREEN_REST_TIME: frozenset(range(0, 5001)),
 
-    # Sleep time (minutes)
-    REGISTER_SLEEP_TIME: frozenset({5, 10, 30, 480}),
+    # Holding 63 — AC scheduled charging time, 1 min per count.
+    # Protocol: "Range: 1~5000"; 0 disables the schedule.
+    REGISTER_STOP_CHARGE_AFTER: frozenset(range(0, 5001)),
 
-    # Stop charge after (minutes) - no possibleValues in app, allow 0-1440
-    REGISTER_STOP_CHARGE_AFTER: frozenset(range(0, 1441)),
+    # Holding 64 — app remote-shutdown function enable.
+    HREG_APP_CONTROL_SLEEP: frozenset({0, 1}),
 
-    # Discharge limit (permille in register, 0-1000 → 0-100%)
-    REGISTER_DISCHARGE_LIMIT: frozenset(range(0, 1001)),
+    # Holding 66 — minimum discharge SOC, 0.1% per count.
+    # Protocol: "Range: 0~500", i.e. a 0-50% floor. Values above 500 are
+    # refused; the integration previously allowed the full 0-100%.
+    REGISTER_DISCHARGE_LIMIT: frozenset(range(0, 501)),
 
-    # Charging limit (permille in register, 0-1000 → 0-100%)
-    REGISTER_CHARGING_LIMIT: frozenset(range(0, 1001)),
+    # Holding 67 — maximum charge SOC in UPS mode, 0.1% per count.
+    # Protocol: "Range: 600~1000", i.e. a 60-100% ceiling. Values below 600
+    # are refused; the integration previously allowed the full 0-100%.
+    REGISTER_CHARGING_LIMIT: frozenset(range(600, 1001)),
+
+    # Holding 68 — whole-unit idle auto-shutdown, 1 min per count.
+    # Protocol: "Range: 1~5000"; 0 disables auto-shutdown.
+    REGISTER_SLEEP_TIME: frozenset(range(0, 5001)),
+
+    # Holding 69 — low-battery notification enable + threshold.
+    HREG_LOW_BATTERY_NOTIFY: _LOW_BATTERY_VALUES,
+
+    # Holding 70 — automatically enable AC output in grid mode.
+    HREG_GRID_AC_AUTO_OUTPUT: frozenset({0, 1}),
+}
+
+# Registers the protocol documents as writable but this integration refuses
+# to touch, with the reason. Kept as data so the intent is testable and a
+# future contributor does not "helpfully" add them back.
+INTENTIONALLY_NOT_WRITABLE: Dict[int, str] = {
+    0: "Factory reset (device and wireless module) — destructive",
+    1: "Debug mode / version query mode — vendor diagnostics only",
+    2: "Chip type selector — vendor diagnostics only",
+    3: "Debug variable address — vendor diagnostics only",
+    4: "Timezone — no documented encoding for the offset field",
 }
 
 
@@ -149,6 +219,12 @@ def get_write_modbus(address: int, feature: int, value: int) -> List[int]:
     """
     allowed = WRITABLE_REGISTERS.get(feature)
     if allowed is None:
+        reason = INTENTIONALLY_NOT_WRITABLE.get(feature)
+        if reason:
+            raise ModbusValidationError(
+                "Register %d is not in WRITABLE_REGISTERS — refusing to "
+                "write: %s" % (feature, reason)
+            )
         raise ModbusValidationError(
             "Register %d is not in WRITABLE_REGISTERS — refusing to write" % feature
         )
@@ -161,7 +237,17 @@ def get_write_modbus(address: int, feature: int, value: int) -> List[int]:
     return aa(address, feature, [a['high'], a['low']], False)
 
 
-def get_read_modbus(address: int, count: int) -> List[int]:
+def pack_byte_pair(high: int, low: int) -> int:
+    """Pack two 8-bit settings into one register value.
+
+    Several holding registers carry two independent 8-bit settings (for
+    example register 69's notification enable and threshold). The protocol's
+    convention is to write 0xFF into the half that should stay unchanged.
+    """
+    return ((high & 0xFF) << 8) | (low & 0xFF)
+
+
+def get_read_modbus(address: int, count: int = MODBUS_READ_COUNT) -> List[int]:
     """Encode a Modbus read holding registers command (function code 03).
 
     Returns settings data on the ``client/data`` MQTT topic.
@@ -169,7 +255,9 @@ def get_read_modbus(address: int, count: int) -> List[int]:
     return ia(address, 0, count, False)
 
 
-def get_read_input_modbus(address: int, count: int) -> List[int]:
+def get_read_input_modbus(
+    address: int, count: int = MODBUS_READ_COUNT
+) -> List[int]:
     """Encode a Modbus read input registers command (function code 04).
 
     Returns sensor data (SoC, power, outputs) on the ``client/04`` topic.
@@ -189,8 +277,8 @@ def _format_allowed(allowed: FrozenSet[int]) -> str:
 # Pre-defined commands (validated at import time)
 # ---------------------------------------------------------------------------
 
-REGRequestSettings      = get_read_modbus(REGISTER_MODBUS_ADDRESS, 80)
-REGRequestSensors       = get_read_input_modbus(REGISTER_MODBUS_ADDRESS, 80)
+REGRequestSettings      = get_read_modbus(REGISTER_MODBUS_ADDRESS)
+REGRequestSensors       = get_read_input_modbus(REGISTER_MODBUS_ADDRESS)
 REGDisableUSBOutput     = get_write_modbus(REGISTER_MODBUS_ADDRESS, REGISTER_USB_OUTPUT, 0)
 REGEnableUSBOutput      = get_write_modbus(REGISTER_MODBUS_ADDRESS, REGISTER_USB_OUTPUT, 1)
 REGDisableDCOutput      = get_write_modbus(REGISTER_MODBUS_ADDRESS, REGISTER_DC_OUTPUT, 0)
@@ -209,63 +297,34 @@ REGEnableACSilentChg    = get_write_modbus(REGISTER_MODBUS_ADDRESS, REGISTER_AC_
 # Register parsing
 # ---------------------------------------------------------------------------
 
-def parse_registers(registers: List[int], topic: str) -> Dict[str, Union[int, float, bool]]:
-    """Parse device registers based on topic and return structured data."""
-    device_update = {}
+# Minimum register count worth decoding. Anything shorter is a write
+# acknowledgement rather than a data response.
+MIN_DATA_REGISTERS = 57
 
-    if len(registers) == 81:
-        if 'device/response/client/04' in topic:
-            # Get register 41 value (active outputs list)
-            register_value = registers[41]
 
-            # Replicate the JavaScript logic exactly
-            # ("0000000000000000" + e[41].toString(2).padStart(8, "0")).slice(-16)
-            binary_str = format(register_value, '016b')
+def parse_registers(
+    registers: List[int], topic: str
+) -> Dict[str, Union[int, float, bool, str, list]]:
+    """Parse device registers based on topic and return structured data.
 
-            device_update.update({
-                "soc": round(registers[56] / 1000 * 100, 1),
-                "dcInput": registers[4],
-                "totalInput": registers[6],
-                "totalOutput": registers[39],
-                "acOutputVoltage": (registers[18] / 10),
-                "acOutputFrequency": (registers[19] / 10),
-                "acInputVoltage": (registers[21] / 10),
-                "acInputFrequency": (registers[22] / 100),
+    The response payload carries the requested registers followed by the
+    frame's CRC word, so ``registers`` is one entry longer than the requested
+    count. Decoding is index-driven and every documented register lives below
+    index 72, so the trailing CRC word is simply never read — and a response
+    of an unexpected length still decodes everything it does contain.
+    """
+    # Anything shorter than this is a write acknowledgement echoing back a
+    # single register, not a data response.
+    if len(registers) < MIN_DATA_REGISTERS:
+        return {}
 
-                # Direct string indexing matches JS array indexing after split
-                "usbOutput": binary_str[6] == '1',   # Position 6: USB Output
-                "dcOutput": binary_str[5] == '1',     # Position 5: DC Output
-                "acOutput": binary_str[4] == '1',     # Position 4: AC Output
-                "ledOutput": binary_str[3] == '1',    # Position 3: LED Output
-            })
-            if registers[53] > 0:
-                device_update.update({
-                    "soc_s1": round(registers[53] / 1000 * 100 - 1, 1),
-                })
-            if registers[55] > 0:
-                device_update.update({
-                    "soc_s2": round(registers[55] / 1000 * 100 - 1, 1),
-                })
-        elif 'device/response/client/data' in topic:
-            device_update.update({
-                "acChargingRate": registers[13],
-                "maximumChargingCurrent": registers[20],
-                "acSilentCharging": (registers[57] == 1),
-                "usbStandbyTime": registers[59],
-                "acStandbyTime": registers[60],
-                "dcStandbyTime": registers[61],
-                "screenRestTime": registers[62],
-                "stopChargeAfter": registers[63],
-                "dischargeLowerLimit": (registers[66] / 10),
-                "acChargingUpperLimit": (registers[67] / 10),
-                "wholeMachineUnusedTime": registers[68]
-            })
-    elif len(registers) >= 57:
-        # Partial update with just SOC
-        device_update["soc"] = round(registers[56] / 1000 * 100, 1)
-        if registers[53] > 0:
-            device_update["soc_s1"] = round(registers[53] / 1000 * 100 - 1, 1)
-        if registers[55] > 0:
-            device_update["soc_s2"] = round(registers[55] / 1000 * 100 - 1, 1)
+    if 'device/response/client/04' in topic:
+        return decode_input_registers(registers)
 
-    return device_update
+    if 'device/response/client/data' in topic:
+        return decode_holding_registers(registers)
+
+    # Unrecognised topic: the same register numbers mean different things in
+    # the holding and input groups, so there is no safe way to decode a
+    # response whose group is unknown.
+    return {}

--- a/custom_components/fossibot-ha/sydpower/mqtt_client.py
+++ b/custom_components/fossibot-ha/sydpower/mqtt_client.py
@@ -11,7 +11,9 @@ import paho.mqtt.client as mqtt
 
 from .const import DEFAULT_MQTT_PORT
 from .logger import SmartLogger
-from .modbus import REGRequestSettings, parse_registers, high_low_to_int
+from .modbus import (
+    MIN_DATA_REGISTERS, REGRequestSettings, high_low_to_int, parse_registers,
+)
 
 CONNECTION_CODES = {
     0: "Connection successful",
@@ -215,7 +217,7 @@ class MQTTClient:
                 for i in range(0, len(data_bytes), 2)
             ]
 
-            if len(registers) < 57:
+            if len(registers) < MIN_DATA_REGISTERS:
                 # Short responses (e.g. 1 register) are normal write ACKs
                 self._logger.debug(
                     "Short response (%d registers) from %s — likely write ACK",

--- a/custom_components/fossibot-ha/sydpower/registers.py
+++ b/custom_components/fossibot-ha/sydpower/registers.py
@@ -1,0 +1,607 @@
+"""V0 register decoding for Fossibot / Sydpower portable power stations.
+
+Every mapping in this module is traceable to the Sydpower "Modbus RTU
+Protocol" document (``Inverter-Protocol-V0.docx``, revision V1.7, 2024-06-01).
+Section references are given per block so a reader can check the source.
+
+Scope note: the same folder also documents the balcony grid-tie inverter
+(``Inverter-Protocol-V1/V2.docx``), which uses a *different* register map at
+the same addresses. This module decodes V0 only. Holding register 5
+(``HREG_PROTOCOL_VERSION``) is surfaced as a diagnostic so a mis-matched
+device can be spotted.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from .const import (
+    BATTERY_TYPES, DC_INPUT_TYPES, DEVICE_MARKET_TYPES, FREQ_TYPES,
+    LIGHT_MODES, VOLTAGE_TYPE_BITS, WIRELESS_COM_BITS,
+    HREG_AC_CHARGE_LEVEL, HREG_AC_CHARGE_MAX_POWER,
+    HREG_AC_CHARGE_APPOINTMENT, HREG_AC_SLEEP_TIME, HREG_APP_CONTROL_SLEEP,
+    HREG_BATTERY_INFO, HREG_BATTERY_PACK_FRAME, HREG_BUZZER,
+    HREG_CHARGE_SOC_MAX, HREG_DC_INPUT_CURRENT_SET, HREG_DC_INPUT_MAX_CURRENT,
+    HREG_DC_INPUT_MAX_POWER, HREG_DC_INPUT_MAX_VOLTAGE,
+    HREG_DC_INPUT_MIN_VOLTAGE, HREG_DC_INPUT_TYPE, HREG_DC_SLEEP_TIME,
+    HREG_DEVICE_TYPE_MODEL, HREG_DISCHARGE_SOC_MIN, HREG_GRID_AC_AUTO_OUTPUT,
+    HREG_LCD_DIM_TIME, HREG_LOW_BATTERY_NOTIFY, HREG_PROTOCOL_VERSION,
+    HREG_SERIAL_FIRST, HREG_SERIAL_LAST, HREG_SHUTDOWN_WAIT_TIME,
+    HREG_SILENT_CHARGING, HREG_USB_SLEEP_TIME, HREG_VERSION_AC,
+    HREG_VERSION_BMS, HREG_VERSION_EXTERNAL_COM, HREG_VERSION_PANEL,
+    HREG_VERSION_PV, HREG_VOLTAGE_FREQ_TYPE, HREG_WIFI_UPLOAD_INTERVAL,
+    HREG_WIRELESS_COM,
+    IREG_5521_POWER, IREG_AC_CHARGE_LEVEL, IREG_AC_CHARGE_POWER,
+    IREG_AC_OUTPUT_FREQUENCY, IREG_AC_OUTPUT_POWER, IREG_AC_OUTPUT_VOLTAGE,
+    IREG_BATTERY_SOC, IREG_BATTERY_USABLE_CAPACITY, IREG_BMS_AFE_STATUS,
+    IREG_BMS_USER_STATUS, IREG_CHARGE_APPOINTMENT_REMAINING,
+    IREG_CHARGE_SOC_AVG, IREG_CIGARETTE_POWER, IREG_DC_CHARGE_POWER,
+    IREG_DISCHARGE_SOC_AVG, IREG_FAULT_AC, IREG_FAULT_AC_2,
+    IREG_FAULT_HIGH_PV, IREG_FAULT_PANEL_H, IREG_FAULT_PANEL_L, IREG_FAULT_PV,
+    IREG_GRID_FREQUENCY, IREG_GRID_VOLTAGE, IREG_INV_OUTPUT_POWER,
+    IREG_INV_OUTPUT_VA, IREG_LED_POWER, IREG_LIGHT_MODE, IREG_PD1_POWER,
+    IREG_PD2_POWER, IREG_PD3_POWER, IREG_PD4_POWER, IREG_PD5_POWER,
+    IREG_PV_ENERGY_TOTAL, IREG_QC1_POWER, IREG_QC2_POWER, IREG_QC3_POWER,
+    IREG_REMAINING_CHARGE_TIME, IREG_REMAINING_DISCHARGE_TIME,
+    IREG_SLAVE_BATTERY_1, IREG_SLAVE_BATTERY_2, IREG_SLAVE_BATTERY_3,
+    IREG_SLAVE_BATTERY_4, IREG_STORAGE_FLAG, IREG_SYSTEM_STATE_H,
+    IREG_SYSTEM_STATE_L, IREG_TOTAL_CHARGE_POWER, IREG_TOTAL_DISCHARGE_POWER,
+    IREG_TYPEC_CHARGE_POWER, IREG_USB1_POWER, IREG_USB2_POWER,
+    IREG_USB3_POWER, IREG_WIRELESS_POWER, IREG_XT60_POWER,
+)
+
+# ---------------------------------------------------------------------------
+# System state — appendix &*8
+#
+# Input registers 41 and 42 together form one 32-bit field: register 41 holds
+# bits 31..16 ("System State H") and register 42 bits 15..0 ("System State L").
+# The integration previously read register 41 alone, which left every bit
+# below 16 — the whole port-state half — unreachable.
+#
+# Keys are the documented bit numbers of the combined 32-bit value.
+# ---------------------------------------------------------------------------
+
+SYSTEM_STATE_BITS: Dict[int, str] = {
+    31: "pvHighVoltageCharging",
+    30: "pvHighVoltagePresent",
+    29: "carCharging",
+    28: "ledOutput",
+    27: "acOutput",
+    26: "dcOutput",
+    25: "usbOutput",
+    24: "carChargeVoltagePresent",
+    23: "dcPortOutput",
+    22: "dcCharging",
+    21: "dcChargeVoltagePresent",
+    20: "gridCharging",
+    19: "gridVoltagePresent",
+    18: "acInverterOutput",
+    17: "gridConnected",
+    16: "wirelessCharging",
+    15: "port5521Output",
+    14: "portCigaretteOutput",
+    13: "portXt60Output",
+    12: "ecoMode",
+    10: "pd5Output",
+    9: "pd4Output",
+    8: "pd3Output",
+    7: "pd2Output",
+    6: "pd1Output",
+    4: "qc2Output",
+    3: "qc1Output",
+    1: "usb2Output",
+    0: "usb1Output",
+}
+
+# ---------------------------------------------------------------------------
+# Fault / status bitfields
+#
+# Each entry maps a bit number to a human-readable fault name. Bits the
+# protocol marks "do not parse" are deliberately absent: for the BMS words
+# those bits carry normal operating state (MOSFET on, charging, balancing),
+# not faults, and reporting them as faults would produce constant false alarms.
+# ---------------------------------------------------------------------------
+
+# Appendix &*9 — input register 43
+FAULT_AC_BITS: Dict[int, str] = {
+    15: "Temperature fault",
+    14: "Battery voltage abnormal",
+    13: "System fault",
+    12: "Relay fault",
+    11: "Grid voltage abnormal (240V)",
+    10: "Grid frequency abnormal (240V)",
+    9: "Grid voltage abnormal (120V)",
+    8: "Grid frequency abnormal (120V)",
+    7: "UPS short circuit (phase A)",
+    6: "Off-grid output overcurrent (phase A)",
+    5: "Off-grid output voltage abnormal (phase A)",
+    4: "Overload level 3 (phase A)",
+    3: "Overload level 2 (phase A)",
+    2: "Overload level 1 (phase A)",
+    1: "BUS overvoltage",
+    0: "Output short circuit (phase A)",
+}
+
+# Appendix &*9 — input register 44 ("AC Fault code_2")
+FAULT_AC2_BITS: Dict[int, str] = {
+    8: "Current sensor fault",
+    6: "Off-grid output overcurrent (phase B)",
+    5: "UPS short circuit (phase B)",
+    4: "Off-grid output voltage abnormal (phase B)",
+    3: "Overload level 3 (phase B)",
+    2: "Overload level 2 (phase B)",
+    1: "Overload level 1 (phase B)",
+    0: "Output short circuit (phase B)",
+}
+
+# Appendix &*10 — input register 45
+FAULT_PV_BITS: Dict[int, str] = {
+    5: "Battery overvoltage",
+    4: "DC 12V channel 3 overcurrent",
+    3: "DC 12V channel 1/2 overcurrent",
+    2: "DC input overcurrent",
+    1: "DC input overvoltage",
+    0: "PV board temperature abnormal",
+}
+
+# Appendix &*9 — input register 46 ("HighPVFaultFlag")
+FAULT_HIGH_PV_BITS: Dict[int, str] = {
+    3: "High-voltage PV overpower",
+    2: "High-voltage PV short circuit",
+    1: "BUS overvoltage",
+    0: "High-voltage PV input overvoltage",
+}
+
+# Appendix &*11 — input register 47. Bits 15, 14, 13, 12, 6 and 0 are marked
+# "do not parse" in the protocol and are omitted.
+FAULT_BMS_AFE_BITS: Dict[int, str] = {
+    11: "AFE discharge over-temperature",
+    10: "AFE discharge under-temperature",
+    9: "AFE charge over-temperature",
+    8: "AFE charge under-temperature",
+    5: "AFE output short circuit",
+    4: "AFE charge overcurrent",
+    3: "AFE discharge overcurrent (level 2)",
+    2: "AFE discharge overcurrent (level 1)",
+    1: "AFE cell undervoltage",
+}
+
+# Appendix &*12 — input register 48. Bits 15..12, 9, 8, 7 and 6 are marked
+# "do not parse" (they report charging/discharging/balancing state).
+FAULT_BMS_USER_BITS: Dict[int, str] = {
+    5: "AFE fault",
+    4: "Battery MOSFET over-temperature",
+    3: "Battery charge under-temperature",
+    2: "Battery charge over-temperature",
+    1: "Battery discharge under-temperature",
+    0: "Battery discharge over-temperature",
+}
+
+# Appendix &*13 — input registers 50 (bits 31..16) and 51 (bits 15..0),
+# combined into one 32-bit value. Keys are bit numbers of the combined value.
+FAULT_PANEL_BITS: Dict[int, str] = {
+    21: "PD4 output overcurrent",
+    20: "PD3 output overcurrent",
+    18: "Wireless charging fault",
+    17: "PD2 output overcurrent",
+    16: "PD1 output overcurrent",
+    7: "Panel board temperature abnormal",
+    4: "DC 24V output overcurrent",
+    3: "DC 12V output overcurrent",
+    2: "QC2 output overcurrent",
+    1: "QC1 output overcurrent",
+    0: "USB1 output overcurrent",
+}
+
+# Informational BMS state bits — the ones the protocol says not to treat as
+# faults. Exposed as attributes on the battery-status sensor instead.
+BMS_AFE_STATE_BITS: Dict[int, str] = {
+    14: "prechargeMosfetOn",
+    13: "chargeMosfetOn",
+    12: "dischargeMosfetOn",
+}
+
+BMS_USER_STATE_BITS: Dict[int, str] = {
+    15: "charging",
+    14: "discharging",
+    13: "fullyDischarged",
+    12: "fullyCharged",
+    7: "batteryOvervoltage",
+    6: "balancing",
+}
+
+
+# ---------------------------------------------------------------------------
+# Primitive decoders
+# ---------------------------------------------------------------------------
+
+def high_byte(value: int) -> int:
+    """Return the high byte of a 16-bit register."""
+    return (value >> 8) & 0xFF
+
+
+def low_byte(value: int) -> int:
+    """Return the low byte of a 16-bit register."""
+    return value & 0xFF
+
+
+def combine_words(high: int, low: int) -> int:
+    """Combine two 16-bit registers into one 32-bit value, high word first."""
+    return ((high & 0xFFFF) << 16) | (low & 0xFFFF)
+
+
+def decode_bits(value: int, table: Dict[int, str]) -> List[str]:
+    """Return the labels of every set bit in ``value`` that ``table`` names."""
+    return [name for bit, name in sorted(table.items(), reverse=True)
+            if value & (1 << bit)]
+
+
+def decode_frequency(raw: int) -> float:
+    """Decode a frequency register, tolerating both documented scalings.
+
+    The protocol gives 0.1 Hz for both the AC output (input 19) and the grid
+    (input 22), but the app this integration was originally reverse-engineered
+    from scaled the grid register by 1/100. Mains frequency is always near
+    50 Hz or 60 Hz, so the two encodings cannot be confused: 0.1 Hz yields
+    ~500-600 and 0.01 Hz yields ~5000-6000. Pick the scale from the magnitude
+    rather than committing to one and being wrong on half the fleet.
+    """
+    if raw >= 1000:
+        return round(raw / 100, 2)
+    return round(raw / 10, 2)
+
+
+def decode_soc_permille(raw: int) -> float:
+    """Decode a 0.1%-per-count SOC register into whole percent."""
+    return round(raw / 10, 1)
+
+
+def decode_slave_soc(raw: int) -> Optional[float]:
+    """Decode a slave-battery SOC register (input 53/55/66/67).
+
+    The protocol encodes these as ``SOC + 10`` over a 10..1010 range in units
+    of 0.1%, with 0 meaning "no battery pack connected".
+    """
+    if raw <= 0:
+        return None
+    return round((raw - 10) / 10, 1)
+
+
+def decode_version(raw: int) -> Optional[Tuple[int, int]]:
+    """Split a board version register into ``(hardware, software)``.
+
+    The protocol packs two independent version numbers into one word
+    (``H8:HardWare L8:SoftWare``). They are kept separate rather than joined
+    with a dot, because "1.20" would read as a single dotted version the
+    device does not actually report.
+    """
+    if raw == 0:
+        return None
+    return high_byte(raw), low_byte(raw)
+
+
+def decode_serial(registers: List[int]) -> Optional[str]:
+    """Decode the serial number from holding registers 72..79.
+
+    Each register carries two characters, most significant first ("SN 16 SN
+    15" down to "SN 2 SN 1"). Non-printable bytes are treated as padding.
+
+    Note on ordering: the document lists the bytes as SN 16 down to SN 1, and
+    that is also the order they arrive in, so they are read lowest register
+    first. If a device ever reports a serial that reads backwards against the
+    label on its case, reverse ``chars`` here — the numbering in the document
+    is descending and does not by itself say which end of the string SN 16 is.
+    """
+    if len(registers) <= HREG_SERIAL_LAST:
+        return None
+
+    chars = []
+    for idx in range(HREG_SERIAL_FIRST, HREG_SERIAL_LAST + 1):
+        for byte in (high_byte(registers[idx]), low_byte(registers[idx])):
+            if 0x20 <= byte <= 0x7E:
+                chars.append(chr(byte))
+            elif byte != 0:
+                # A non-ASCII byte means this is not a text serial number.
+                return None
+
+    serial = "".join(chars).strip()
+    return serial or None
+
+
+def _flag_names(bits: Dict[int, str], value: int) -> Dict[str, bool]:
+    """Expand a bitfield into a ``{name: bool}`` mapping."""
+    return {name: bool(value & (1 << bit)) for bit, name in bits.items()}
+
+
+# ---------------------------------------------------------------------------
+# Holding registers (function 03) — settings and identity
+# ---------------------------------------------------------------------------
+
+def decode_holding_registers(registers: List[int]) -> Dict[str, Any]:
+    """Decode a holding-register (function 03) response.
+
+    Only registers actually present in ``registers`` are decoded, so a short
+    response degrades gracefully instead of being discarded.
+    """
+    out: Dict[str, Any] = {}
+
+    def reg(index: int) -> Optional[int]:
+        return registers[index] if index < len(registers) else None
+
+    # --- Controls the integration can write back -------------------------
+    _set(out, "acChargingRate", reg(HREG_AC_CHARGE_LEVEL))
+    _set(out, "maximumChargingCurrent",
+         _map(reg(HREG_DC_INPUT_CURRENT_SET), low_byte))
+    _set(out, "acSilentCharging", _map(reg(HREG_SILENT_CHARGING),
+                                       lambda v: low_byte(v) == 1))
+    _set(out, "buzzerEnabled", _map(reg(HREG_BUZZER),
+                                    lambda v: low_byte(v) == 1))
+    _set(out, "appControlSleep", _map(reg(HREG_APP_CONTROL_SLEEP),
+                                      lambda v: low_byte(v) == 1))
+    _set(out, "gridAcAutoOutput", _map(reg(HREG_GRID_AC_AUTO_OUTPUT),
+                                       lambda v: v == 1))
+    _set(out, "usbStandbyTime", reg(HREG_USB_SLEEP_TIME))
+    _set(out, "acStandbyTime", reg(HREG_AC_SLEEP_TIME))
+    _set(out, "dcStandbyTime", reg(HREG_DC_SLEEP_TIME))
+    _set(out, "screenRestTime", reg(HREG_LCD_DIM_TIME))
+    _set(out, "stopChargeAfter", reg(HREG_AC_CHARGE_APPOINTMENT))
+    _set(out, "wholeMachineUnusedTime", reg(HREG_SHUTDOWN_WAIT_TIME))
+    _set(out, "wifiUploadInterval", reg(HREG_WIFI_UPLOAD_INTERVAL))
+    _set(out, "dischargeLowerLimit",
+         _map(reg(HREG_DISCHARGE_SOC_MIN), decode_soc_permille))
+    _set(out, "acChargingUpperLimit",
+         _map(reg(HREG_CHARGE_SOC_MAX), decode_soc_permille))
+
+    dc_input_type = reg(HREG_DC_INPUT_TYPE)
+    if dc_input_type is not None:
+        code = low_byte(dc_input_type)
+        out["dcInputType"] = DC_INPUT_TYPES.get(code, "Unknown (%d)" % code)
+        out["dcInputTypeRaw"] = code
+
+    # Register 69 packs the enable flag and the threshold into one word.
+    low_battery = reg(HREG_LOW_BATTERY_NOTIFY)
+    if low_battery is not None:
+        enable = high_byte(low_battery)
+        threshold = low_byte(low_battery)
+        if enable != 0xFF:
+            out["lowBatteryNotifyEnabled"] = enable == 1
+        if threshold != 0xFF:
+            out["lowBatteryNotifyThreshold"] = threshold
+
+    # --- Static capability / identity data -------------------------------
+    _set(out, "acChargeMaxPower", reg(HREG_AC_CHARGE_MAX_POWER))
+    _set(out, "dcInputMaxPower", reg(HREG_DC_INPUT_MAX_POWER))
+    _set(out, "dcInputMaxCurrent",
+         _map(reg(HREG_DC_INPUT_MAX_CURRENT), low_byte))
+    _set(out, "dcInputMinVoltage",
+         _map(reg(HREG_DC_INPUT_MIN_VOLTAGE), lambda v: round(v / 10, 1)))
+    _set(out, "dcInputMaxVoltage",
+         _map(reg(HREG_DC_INPUT_MAX_VOLTAGE), lambda v: round(v / 10, 1)))
+    _set(out, "protocolVersion",
+         _map(reg(HREG_PROTOCOL_VERSION), lambda v: v & 0x0F))
+
+    device_type = reg(HREG_DEVICE_TYPE_MODEL)
+    if device_type:
+        market = high_byte(device_type)
+        out["deviceMarketType"] = DEVICE_MARKET_TYPES.get(
+            market, "Unknown (%d)" % market
+        )
+        out["deviceModelCode"] = "%03d" % low_byte(device_type)
+
+    voltage_freq = reg(HREG_VOLTAGE_FREQ_TYPE)
+    if voltage_freq:
+        voltages = [
+            label for bit, label in sorted(VOLTAGE_TYPE_BITS.items(),
+                                           reverse=True)
+            if voltage_freq & (1 << bit)
+        ]
+        if voltages:
+            out["deviceVoltageType"] = ", ".join(voltages)
+        freq_code = voltage_freq & 0x07
+        if freq_code in FREQ_TYPES:
+            out["deviceFrequencyType"] = FREQ_TYPES[freq_code]
+
+    battery_info = reg(HREG_BATTERY_INFO)
+    if battery_info:
+        chemistry = high_byte(battery_info)
+        out["batteryChemistry"] = BATTERY_TYPES.get(
+            chemistry, "Unknown (%d)" % chemistry
+        )
+        out["batteryCapacityAh"] = low_byte(battery_info)
+
+    pack_frame = reg(HREG_BATTERY_PACK_FRAME)
+    if pack_frame:
+        out["batteryCellsSeries"] = high_byte(pack_frame)
+        out["batteryCellsParallel"] = low_byte(pack_frame)
+
+    wireless_com = reg(HREG_WIRELESS_COM)
+    if wireless_com:
+        radios = [
+            label for bit, label in sorted(WIRELESS_COM_BITS.items(),
+                                           reverse=True)
+            if wireless_com & (1 << bit)
+        ]
+        if radios:
+            out["wirelessModules"] = ", ".join(radios)
+
+    for key, index in (
+        ("versionAc", HREG_VERSION_AC),
+        ("versionBms", HREG_VERSION_BMS),
+        ("versionPv", HREG_VERSION_PV),
+        ("versionPanel", HREG_VERSION_PANEL),
+        ("versionExternalCom", HREG_VERSION_EXTERNAL_COM),
+    ):
+        version = _map(reg(index), decode_version)
+        if version is not None:
+            out["%sHardware" % key] = version[0]
+            out["%sSoftware" % key] = version[1]
+
+    _set(out, "serialNumber", decode_serial(registers))
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Input registers (function 04) — live measurements
+# ---------------------------------------------------------------------------
+
+# (key, register index, scale) for the plain scalar measurements.
+_INPUT_SCALARS: Tuple[Tuple[str, int, float], ...] = (
+    ("acChargeLevelActive", IREG_AC_CHARGE_LEVEL, 1),
+    ("acInput", IREG_AC_CHARGE_POWER, 1),
+    ("dcInput", IREG_DC_CHARGE_POWER, 1),
+    ("typecInput", IREG_TYPEC_CHARGE_POWER, 1),
+    ("totalInput", IREG_TOTAL_CHARGE_POWER, 1),
+    ("xt60Power", IREG_XT60_POWER, 0.1),
+    ("cigarettePower", IREG_CIGARETTE_POWER, 0.1),
+    ("port5521Power", IREG_5521_POWER, 0.1),
+    ("wirelessChargingPower", IREG_WIRELESS_POWER, 0.1),
+    ("ledPower", IREG_LED_POWER, 1),
+    ("inverterOutputPower", IREG_INV_OUTPUT_POWER, 1),
+    ("inverterOutputApparentPower", IREG_INV_OUTPUT_VA, 1),
+    ("acOutputPower", IREG_AC_OUTPUT_POWER, 1),
+    ("usb1Power", IREG_USB1_POWER, 0.1),
+    ("usb2Power", IREG_USB2_POWER, 0.1),
+    ("usb3Power", IREG_USB3_POWER, 0.1),
+    ("qc1Power", IREG_QC1_POWER, 0.1),
+    ("qc2Power", IREG_QC2_POWER, 0.1),
+    ("qc3Power", IREG_QC3_POWER, 0.1),
+    ("pd1Power", IREG_PD1_POWER, 0.1),
+    ("pd2Power", IREG_PD2_POWER, 0.1),
+    ("pd3Power", IREG_PD3_POWER, 0.1),
+    ("pd4Power", IREG_PD4_POWER, 0.1),
+    ("pd5Power", IREG_PD5_POWER, 0.1),
+    ("totalOutput", IREG_TOTAL_DISCHARGE_POWER, 1),
+    ("batteryUsableCapacity", IREG_BATTERY_USABLE_CAPACITY, 1),
+    ("chargeAppointmentRemaining", IREG_CHARGE_APPOINTMENT_REMAINING, 1),
+    ("remainingChargeTime", IREG_REMAINING_CHARGE_TIME, 1),
+    ("remainingDischargeTime", IREG_REMAINING_DISCHARGE_TIME, 1),
+    ("averageDischargeSoc", IREG_DISCHARGE_SOC_AVG, 1),
+    ("averageChargeSoc", IREG_CHARGE_SOC_AVG, 1),
+)
+
+_SLAVE_SOC_REGISTERS: Tuple[Tuple[str, int], ...] = (
+    ("soc_s1", IREG_SLAVE_BATTERY_1),
+    ("soc_s2", IREG_SLAVE_BATTERY_2),
+    ("soc_s3", IREG_SLAVE_BATTERY_3),
+    ("soc_s4", IREG_SLAVE_BATTERY_4),
+)
+
+
+def decode_input_registers(registers: List[int]) -> Dict[str, Any]:
+    """Decode an input-register (function 04) response."""
+    out: Dict[str, Any] = {}
+
+    def reg(index: int) -> Optional[int]:
+        return registers[index] if index < len(registers) else None
+
+    for key, index, scale in _INPUT_SCALARS:
+        raw = reg(index)
+        if raw is None:
+            continue
+        out[key] = raw if scale == 1 else round(raw * scale, 1)
+
+    _set(out, "soc", _map(reg(IREG_BATTERY_SOC), decode_soc_permille))
+    for key, index in _SLAVE_SOC_REGISTERS:
+        raw = reg(index)
+        if raw is None:
+            continue
+        value = decode_slave_soc(raw)
+        if value is not None:
+            out[key] = value
+
+    _set(out, "acOutputVoltage",
+         _map(reg(IREG_AC_OUTPUT_VOLTAGE), lambda v: round(v / 10, 1)))
+    _set(out, "acOutputFrequency",
+         _map(reg(IREG_AC_OUTPUT_FREQUENCY), decode_frequency))
+    _set(out, "acInputVoltage",
+         _map(reg(IREG_GRID_VOLTAGE), lambda v: round(v / 10, 1)))
+    _set(out, "acInputFrequency",
+         _map(reg(IREG_GRID_FREQUENCY), decode_frequency))
+
+    _set(out, "storageFlag", _map(reg(IREG_STORAGE_FLAG),
+                                  lambda v: low_byte(v) == 1))
+
+    light_mode = reg(IREG_LIGHT_MODE)
+    if light_mode is not None:
+        code = low_byte(light_mode)
+        out["lightModeRaw"] = code
+        out["lightMode"] = LIGHT_MODES.get(code, "Unknown (%d)" % code)
+
+    # PV lifetime energy: the register is offset by one so that 0 can mean
+    # "this device has no PV energy counter" (protocol note on input 60:
+    # "1~(65500-1), 0: no accumulation function ... upload N+1").
+    pv_energy = reg(IREG_PV_ENERGY_TOTAL)
+    if pv_energy:
+        out["pvEnergyTotal"] = round((pv_energy - 1) * 100 / 1000, 1)
+
+    out.update(_decode_system_state(reg(IREG_SYSTEM_STATE_H),
+                                    reg(IREG_SYSTEM_STATE_L)))
+    out.update(_decode_faults(registers))
+
+    return out
+
+
+def _decode_system_state(
+    state_high: Optional[int], state_low: Optional[int]
+) -> Dict[str, Any]:
+    """Decode the 32-bit system-state field (input registers 41 + 42)."""
+    if state_high is None:
+        return {}
+
+    # A device that does not populate "System State L" simply reports zero
+    # there; the low-half flags then read as off, which is the safe default.
+    combined = combine_words(state_high, state_low or 0)
+
+    out: Dict[str, Any] = _flag_names(SYSTEM_STATE_BITS, combined)
+    out["systemStateRaw"] = combined
+    return out
+
+
+def _decode_faults(registers: List[int]) -> Dict[str, Any]:
+    """Decode every fault/status word into named fault lists."""
+
+    def reg(index: int) -> int:
+        return registers[index] if index < len(registers) else 0
+
+    ac_faults = (decode_bits(reg(IREG_FAULT_AC), FAULT_AC_BITS)
+                 + decode_bits(reg(IREG_FAULT_AC_2), FAULT_AC2_BITS))
+    pv_faults = (decode_bits(reg(IREG_FAULT_PV), FAULT_PV_BITS)
+                 + decode_bits(reg(IREG_FAULT_HIGH_PV), FAULT_HIGH_PV_BITS))
+    bms_faults = (decode_bits(reg(IREG_BMS_AFE_STATUS), FAULT_BMS_AFE_BITS)
+                  + decode_bits(reg(IREG_BMS_USER_STATUS),
+                                FAULT_BMS_USER_BITS))
+    panel_faults = decode_bits(
+        combine_words(reg(IREG_FAULT_PANEL_H), reg(IREG_FAULT_PANEL_L)),
+        FAULT_PANEL_BITS,
+    )
+
+    all_faults = ac_faults + pv_faults + bms_faults + panel_faults
+
+    out: Dict[str, Any] = {
+        "faultsAc": ac_faults,
+        "faultsPv": pv_faults,
+        "faultsBms": bms_faults,
+        "faultsPanel": panel_faults,
+        "faults": all_faults,
+        "faultCount": len(all_faults),
+        "hasFault": bool(all_faults),
+    }
+
+    out.update(_flag_names(BMS_AFE_STATE_BITS, reg(IREG_BMS_AFE_STATUS)))
+    out.update(_flag_names(BMS_USER_STATE_BITS, reg(IREG_BMS_USER_STATUS)))
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Small helpers used by the decoders above
+# ---------------------------------------------------------------------------
+
+def _set(target: Dict[str, Any], key: str, value: Any) -> None:
+    """Assign ``key`` only when a value was actually decoded."""
+    if value is not None:
+        target[key] = value
+
+
+def _map(value: Optional[int], fn) -> Any:
+    """Apply ``fn`` to ``value`` unless it is missing."""
+    return None if value is None else fn(value)

--- a/docs/PROTOCOL_AUDIT.md
+++ b/docs/PROTOCOL_AUDIT.md
@@ -1,0 +1,310 @@
+# Protocol audit — vendor documentation vs. integration
+
+> This audit exists because the **Sydpower technical team** shared their
+> complete protocol documentation with this project, voluntarily and with
+> nothing asked in return. Every finding below is a thing that could only be
+> found by having the specification in writing. Thank you.
+
+Audited against the Sydpower documentation set (`inverter-protocol-en`),
+supplied by the Sydpower engineering team:
+
+| Document | Revision | Covers |
+|----------|----------|--------|
+| `Inverter-Protocol-V0.docx` | V1.7, 2024-06-01 | **Portable power stations** — the devices this integration supports |
+| `Inverter-Protocol-V1.docx` | V1.0, 2024-08-22 | Balcony grid-tie inverter, protocol version 1 |
+| `Inverter-Protocol-V2.docx` | V1.0 | Balcony grid-tie inverter, protocol version 2 |
+| `Firmware-Upgrade-Implementation-Details.docx` | — | Segmented firmware upload (function `0x26`) |
+
+Everything below concerns **V0**. V1/V2 are a different device class and are
+covered in [Not implemented](#not-implemented) at the end.
+
+---
+
+## Confirmed correct
+
+The reverse-engineered foundation held up. These were checked line by line
+against the document and needed no change:
+
+- **Slave address 17 (0x11)** — matches the `Slave Address 11` hex examples used
+  throughout section 1.
+- **CRC-16/Modbus**, init `0xFFFF`, polynomial `0xA001`, appended **high byte
+  first**. Matches `getCRC16_MODBUS` and `getModbusDataCRCLowFront(..., false)`
+  in the firmware-upgrade document verbatim.
+- **Function 3 / 4 / 6** framing, including the response layout: over MQTT the
+  reply carries `addr, func, startHi, startLo, countHi, countLo` and then the
+  data, with no serial-number block. This is why a 6-byte offset lands exactly
+  on register 0, and why an 80-register read decodes as 81 words — the last
+  one is the frame CRC.
+- **Battery SOC** — input 56, 0.1% per count.
+- **Slave battery SOC** — inputs 53/55, encoded `SOC + 10` over 10..1010 with
+  0 meaning "no pack connected". The existing `raw / 1000 * 100 - 1` is
+  algebraically identical to the documented `(raw - 10) / 10`.
+- **Output button registers** — holding 24/25/26/27 for USB/DC/AC/LED.
+- **Settings registers** — holding 13, 20, 57, 59, 60, 61, 62, 63, 66, 67, 68.
+- **System-state bit positions** for the four bits that were being read
+  (28 LED, 27 AC, 26 DC, 25 USB) — the old string-slicing arithmetic was
+  correct, just very narrow.
+
+---
+
+## Defects found and fixed
+
+### 1. Charge/discharge limits accepted out-of-spec values — *safety*
+
+`WRITABLE_REGISTERS` allowed `0..1000` for both SOC limits.
+
+| Register | Documented range | Was allowed | Now |
+|----------|------------------|-------------|-----|
+| Holding 66 — minimum discharge SOC | `0~500` (0-50%) | 0-100% | 0-50% |
+| Holding 67 — maximum charge SOC, UPS mode | `600~1000` (60-100%) | 0-100% | 60-100% |
+
+`modbus.py` opens with the warning that this firmware does not validate writes
+and that an out-of-range value can brick a device — and then shipped sliders
+that could write values the vendor never documented. The number entities now
+expose 0-50% and 60-100% respectively.
+
+**Behaviour change:** a charge ceiling below 60% is no longer selectable.
+
+### 2. Grid frequency was reported ~100× low
+
+Input 22 is documented as 0.1 Hz, the same as the AC output frequency in input
+19. The code scaled input 19 by 1/10 and input 22 by 1/100 — one of the two had
+to be wrong, and the document says it is the grid one.
+
+Rather than swap one guess for another, `decode_frequency()` now picks the
+scale from the magnitude. Mains frequency is always near 50 or 60 Hz, so 0.1 Hz
+encoding yields ~500-600 and 0.01 Hz yields ~5000-6000; the ranges cannot
+overlap, so the decision is unambiguous on either firmware.
+
+### 3. Half the system-state field was unreachable
+
+Inputs 41 and 42 form **one 32-bit field**: 41 holds bits 31..16 ("System
+State H") and 42 holds bits 15..0 ("System State L"). The integration read
+register 41 alone and extracted 4 bits from it. Register 42 was never looked
+at, so the entire low half — every individual port, ECO mode, the 12 V outputs
+— was invisible.
+
+All 28 documented bits are now decoded and exposed via the new
+`binary_sensor` platform.
+
+### 4. No fault reporting at all
+
+Eight fault/status words were being read off the wire and discarded:
+
+| Register | Word |
+|----------|------|
+| input 43 | AC fault code (appendix &\*9) |
+| input 44 | AC fault code 2 |
+| input 45 | PV fault code (&\*10) |
+| input 46 | High-voltage PV fault flags |
+| input 47 | BMS AFE status (&\*11) |
+| input 48 | BMS user status (&\*12) |
+| input 50/51 | Panel fault code, 32-bit (&\*13) |
+
+All are decoded into named faults, aggregated onto a `problem` binary sensor
+and an "Active Faults" count with the fault names as attributes.
+
+The bits the protocol marks **"do not parse"** are excluded from the fault
+lists — in the BMS words those bits carry normal operating state (MOSFET
+closed, charging, balancing), and treating them as faults would raise a
+permanent false alarm. The genuinely useful ones are surfaced separately as
+diagnostic binary sensors.
+
+### 5. LED mode could not be read back
+
+The LED select wrote holding 27 but had no way to read the current mode, so it
+cached the last option it had set and reported `Off`/`On` only — SOS and Flash
+were unrepresentable, and the state was wrong after any change made on the
+device itself.
+
+Input register 25 (`L8:LightMode`, `0=off 1=steady 2=SOS 3=strobe`) reports it
+directly. The select is now an ordinary register select reading that value, and
+the guessing is gone.
+
+### 6. "Maximum Charging Current" was mislabelled as AC
+
+Holding 20 is `DC Input Max Curr SET` — the **DC** (PV / vehicle) charging
+current. The entity was named "Maximum Charging Current" and the README
+documented it as "AC charging current limit". Renamed to "DC Input Charging
+Current Limit"; the `unique_id` is unchanged, so existing entity IDs and
+automations keep working.
+
+### 7. The device's own current limit was never enforced
+
+The protocol constrains holding 20 to "< DC Input Max Curr", which is holding
+17 and varies per model — so it cannot live in a static allowlist. Holding 17
+was not being read. It is now decoded, the slider maximum narrows to it, and
+`run_command()` re-checks it so a service call that bypasses the UI is still
+rejected.
+
+### 8. Parsing was locked to one exact response length
+
+`parse_registers` required `len(registers) == 81` for full decoding and
+otherwise fell back to SOC-only. Since the read count comes from the API
+(`productInfo.modbus_count`), any device reporting something other than 80
+would have silently lost every sensor but SOC.
+
+Decoding is now index-driven: each field is read if the response is long enough
+to contain it. A short response yields everything it does carry, and the
+trailing CRC word is simply never indexed. The read count from the API is also
+clamped to the protocol's 100-word maximum.
+
+### 9. Unknown-topic responses were decoded inconsistently
+
+The old length-based fallback meant an unrecognised topic yielded `{}` at full
+length but a SOC value at partial length. The same register number means
+different things in the holding and input groups, so a response whose group is
+unknown cannot be decoded safely either way — it now returns nothing in both
+cases.
+
+### 10. The test suite mirrored the entity tables by hand
+
+`tests/test_entity_definitions.py` contained copies of the definition dicts
+because the platform modules import Home Assistant. The copies had drifted, so
+the coverage tests were passing against stale data.
+
+`conftest.py` now installs Home Assistant / paho / aiohttp stubs (as real
+classes, since the platform modules subclass them) and the tests import the
+live tables. Two genuine gaps surfaced immediately: the LED on/off state bit
+had lost its entity in the LED-select rework, and the serial-number decoder was
+never exercised.
+
+---
+
+## Features added
+
+Registers that were documented, already arriving in every poll, and being
+thrown away.
+
+### Measurements — `sensor`
+
+| Register | Entity |
+|----------|--------|
+| input 03 | AC Input power |
+| input 05 | USB-C Input power |
+| input 08/09/10 | XT60 / cigarette / 5521 port power |
+| input 13 | Wireless charging power |
+| input 15 | LED power |
+| input 16/17 | Inverter output power / apparent power |
+| input 20 | AC output power |
+| input 26-28 | USB 1-3 power |
+| input 30-32 | QC 1-3 power |
+| input 34-38 | PD 1-5 power |
+| input 54 | Battery usable capacity (Ah) |
+| input 57/58/59 | Charge schedule remaining, remaining charge / discharge time |
+| input 60 | PV lifetime energy — `TOTAL_INCREASING`, so it feeds the HA energy dashboard |
+| input 66/67 | Slave battery 3 and 4 SOC |
+| input 70/71 | Average discharge / charge SOC |
+| holding 14/16/17/18/19 | AC charge max power, DC input max power / current / voltage window |
+| holding 40/41 | Battery chemistry, capacity, cell topology |
+| holding 5 | Protocol version |
+
+Input register 60 carries a `+1` offset so that 0 can mean "no counter
+fitted"; the decoder removes it, so the sensor is a true lifetime total rather
+than being 100 Wh high forever.
+
+Per-port breakdowns are created disabled — they are there when you need to
+diagnose one socket, without adding two dozen mostly-zero entities.
+
+### State — `binary_sensor` (new platform)
+
+Grid / DC / PV / car charging and input presence, on-grid vs off-grid, AC
+inverter output, DC port output, wireless charging, ECO mode, all individual
+USB / QC / PD / 12 V ports, BMS charge and discharge MOSFET state, charging /
+discharging / full / balancing, and the aggregate fault sensor.
+
+### Controls
+
+| Register | Entity | Type |
+|----------|--------|------|
+| holding 13 | AC Charging Rate (levels 1-5) | select — was read-only before |
+| holding 15 | DC Input Type (MPPT / DC source) | select |
+| holding 54 | Wi-Fi Upload Interval | number |
+| holding 56 | Buzzer | switch |
+| holding 64 | App Remote Shutdown | switch |
+| holding 69 | Low Battery Notification + threshold | switch + number |
+| holding 70 | Grid Mode AC Auto Output | switch |
+
+Holding 69 packs two independent 8-bit settings into one word. The protocol's
+convention is to write `0xFF` into the half that should stay unchanged, which
+is exactly how the enable switch and the threshold slider write it, so setting
+one never clobbers the other.
+
+### Device identity
+
+Holding 11 (market type + model code), 47-51 (AC / BMS / PV / Panel / Com
+board versions) and 72-79 (serial number, two ASCII characters per register)
+now populate the HA device registry, so a device page shows real model,
+firmware and serial number rather than just a MAC address.
+
+### Registers deliberately left unwritable
+
+`INTENTIONALLY_NOT_WRITABLE` records these with reasons, so the decision is
+visible and testable rather than an accident of omission:
+
+| Register | Reason |
+|----------|--------|
+| holding 0 | Factory reset (device and wireless module) — destructive |
+| holding 1 | Debug / version query mode — vendor diagnostics |
+| holding 2 | Chip type selector — vendor diagnostics |
+| holding 3 | Debug variable address — vendor diagnostics |
+| holding 4 | Timezone — the document gives no encoding for the offset field |
+
+---
+
+## Deviations from the document
+
+Two places where the shipped allowlist is not a literal copy of the spec:
+
+1. **Holding 62 (screen dim time)** — documented `1~5000`, but 0 is allowed
+   because the vendor app itself offers an "off" option for this setting,
+   which is evidence the firmware accepts it. Same reasoning applies to 0 on
+   holding 63 and 68, which the document also starts at 1.
+2. **Holding 54 (Wi-Fi upload interval)** — the document gives the unit (1 s)
+   but no range. Bounded to 5 s..1 h, comfortably inside any plausible
+   firmware limit.
+
+---
+
+## Not implemented
+
+### Balcony grid-tie inverters (protocol V1 / V2)
+
+A different device class that reuses the same register numbers for entirely
+different meanings — holding 41 is `Battery Pack Frame` in V0 and
+`Grid Charge time 2` in V2. Supporting both needs a protocol-version-selected
+register profile, keyed on holding 7 (`L4:Protocol Version`) for V1/V2 versus
+holding 5 for V0.
+
+What a V2 profile would add: 3 custom + 3 AI grid-charge windows, 12 grid-tie
+discharge windows with per-window power and day-of-week masks, immediate
+force-charge / force-export, load-following (anti-backflow) and PV
+self-consumption modes, up to 8 smart sockets and a 3-phase smart meter with
+per-socket and per-phase power and energy, lifetime battery charge/discharge
+and household-load energy counters, SOH, battery temperatures, negative
+electricity price windows, and charge-priority mode.
+
+Holding register 5 is decoded and exposed as a "Protocol Version" diagnostic
+sensor so a mismatched device can be identified from the HA UI.
+
+### Firmware upload (function `0x26`)
+
+Fully documented, including the segmentation rules (192 bytes/frame for
+`DSP_AC`, 200 otherwise; skip the first 16 KB for `AC` firmware, 10 KB
+otherwise; 20 KB for DSP157; drop the last 16 KB for DSP28034), the
+`packNum`-echo handshake and the 7 s / 6-retry timeout policy.
+
+Not implemented deliberately: a botched flash bricks hardware, the process
+needs vendor firmware images this integration has no source for, and Home
+Assistant is the wrong place to run it. Use the BrightEMS app.
+
+### Other unimplemented documented surfaces
+
+- **Function 7 (Wi-Fi provisioning)** — belongs to onboarding, which happens
+  in the app.
+- **Smart socket / meter protocol** (addresses 100-113, functions 100/101/102/105)
+  — V1/V2 accessories.
+- **Chart requests** (input addresses 10001+, 288-point series) — V2 only, and
+  the document notes they are MQTT-only because of the Bluetooth MTU.
+- **HTTP endpoints** `emqx.pub_5min` / `emqx.pub_device` — these are how the
+  *device* pushes to the vendor cloud, not something a client calls.

--- a/readme.md
+++ b/readme.md
@@ -1,200 +1,427 @@
 # Fossibot Home Assistant Integration
 
 [![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
-[![GitHub Release](https://img.shields.io/github/v/release/iamslan/fossibot)](https://github.com/iamslan/fossibot/releases)
-[![License: MIT](https://img.shields.io/github/license/iamslan/fossibot)](LICENSE)
+[![GitHub Release](https://img.shields.io/github/v/release/iamslan/ha-fossibot)](https://github.com/iamslan/ha-fossibot/releases)
+[![License: MIT](https://img.shields.io/github/license/iamslan/ha-fossibot)](LICENSE)
 
-A custom [Home Assistant](https://www.home-assistant.io/) integration to monitor and control **Fossibot / Sydpower** portable power stations via a **local MQTT broker**.
+Monitor and control **Fossibot / Sydpower** portable power stations from
+[Home Assistant](https://www.home-assistant.io/) over your **own MQTT broker** —
+no cloud MQTT in the data path.
 
-> **Disclaimer** — This integration is unofficial and not affiliated with Fossibot, Sydpower, or BrightEMS. **Use at your own risk.** The authors are not responsible for any damage to your devices.
+Every register is decoded against the official Modbus protocol specification,
+shared with this project by the Sydpower technical team
+([thank you](#thank-you-sydpower)). What is implemented, what was found wrong
+along the way, and what is deliberately left out is documented in
+**[docs/PROTOCOL_AUDIT.md](docs/PROTOCOL_AUDIT.md)**.
 
-[Join our Discord](https://discord.gg/2jKxpxGg9D) to help with development, report issues, or share feedback about your battery model.
+> **Unofficial integration.** Not affiliated with Fossibot, Sydpower or
+> BrightEMS. **Use at your own risk** — see [Writing to your device](#writing-to-your-device).
+
+[Join the Discord](https://discord.gg/2jKxpxGg9D) to help with development,
+report issues, or share results for your model.
 
 ---
 
-## Features
+## Contents
 
-- **Local MQTT** — connects to your own MQTT broker, no cloud MQTT dependency
-- **11 sensors** — battery SoC (+ slave 1 & 2), power input/output, AC voltage & frequency
-- **4 switches** — USB, DC, AC output toggles + AC silent charging
-- **6 selects** — LED mode, USB/AC/DC standby time, screen rest time, sleep time
-- **4 number controls** — max charging current, stop charge timer, discharge/charge limits
-- **Device state sync** — automatically reports device online/offline status to the SYDPOWER platform
-- **Write protection** — every register write validated against a safety whitelist
-- **Auto-reconnection** — exponential backoff with connection verification
-- **Per-device Modbus addressing** — extracted from API, not hardcoded
+- [Requirements](#requirements)
+- [Supported devices](#supported-devices)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Entities](#entities)
+- [Writing to your device](#writing-to-your-device)
+- [Troubleshooting](#troubleshooting)
+- [Not supported](#not-supported)
+- [For contributors](#for-contributors)
+- [Thank you, Sydpower](#thank-you-sydpower)
 
-## Prerequisites
+---
 
-- **BrightEMS app** version **1.6.0** or later
-- A **local MQTT broker** (e.g. [Mosquitto](https://mosquitto.org/), [EMQX](https://www.emqx.io/)) reachable by your devices on **TCP port 1883**
-- Local MQTT Broker configured in the BrightEMS app (see [Setup](#setup) below)
+## Requirements
 
-## Supported Devices
+| | |
+|---|---|
+| **BrightEMS app** | version **1.6.0** or later |
+| **MQTT broker** | e.g. [Mosquitto](https://mosquitto.org/) or [EMQX](https://www.emqx.io/), reachable **by your power station** on TCP port 1883 |
+| **Internet** | needed once at startup for the device list, and for online/offline state sync — the telemetry itself is local |
 
-Compatible with power stations that use the **BrightEMS** app. All these brands share the same **SYDPOWER** platform:
+The broker must be reachable from the power station, not just from Home
+Assistant. The device connects to it directly.
 
-| Brand | Models | Evidence |
-|-------|--------|----------|
-| **FOSSiBOT** | F2400, F3600, F3600 Pro, F1200 | Uses BrightEMS app, confirmed by multiple GitHub reverse-engineering projects |
-| **AFERIY** | P210, P310 | Uses BrightEMS app, identical specs to Fossibot F2400/F3600 |
-| **Eco Play (ECOPLAY)** | SYD2400, SYD3600, 3600 Pro | Literally uses "SYD" in model names, uses BrightEMS app, expansion battery called "SYD3600-Extra" |
-| **ABOK Power** | Ark3600 | Uses BrightEMS app, listed as compatible in ESP-FBot project |
+## Supported devices
 
-### Model cross-reference (SYDPOWER internal model -> brand equivalents)
+Anything that pairs with the **BrightEMS** app runs on the same SYDPOWER
+platform and should work:
 
-- **SYDPOWER N052** (2400W/2048Wh) -> FOSSiBOT F2400 -> AFERIY P210 -> Eco Play SYD2400
-- **SYDPOWER N051/N066** (3600W/3840Wh) -> FOSSiBOT F3600 Pro -> AFERIY P310 -> Eco Play SYD3600 -> ABOK Ark3600
+| Brand | Models |
+|-------|--------|
+| **FOSSiBOT** | F1200, F2400, F3600, F3600 Pro |
+| **AFERIY** | P210, P310 |
+| **Eco Play (ECOPLAY)** | SYD2400, SYD3600, 3600 Pro |
+| **ABOK Power** | Ark3600 |
 
-If your BrightEMS-compatible model is not listed, please report your results on Discord or GitHub Issues.
+The same hardware is sold under several names, so a model listed for one brand
+usually confirms its siblings:
+
+- **SYDPOWER N052** — 2400 W / 2048 Wh — FOSSiBOT F2400 · AFERIY P210 · Eco Play SYD2400
+- **SYDPOWER N051 / N066** — 3600 W / 3840 Wh — FOSSiBOT F3600 Pro · AFERIY P310 · Eco Play SYD3600 · ABOK Ark3600
+
+Not listed? It will most likely still work — please report the result on
+Discord or in a GitHub issue so the table can grow. Expansion batteries are
+picked up automatically (up to four).
 
 ## Installation
 
 ### HACS (recommended)
 
-1. Open **HACS** > **Integrations** > **Custom Repositories**
-2. Add `https://github.com/iamslan/fossibot` as an **Integration**
-3. Search for **Fossibot** and install it
+1. **HACS** → **Integrations** → **Custom Repositories**
+2. Add `https://github.com/iamslan/ha-fossibot` as an **Integration**
+3. Search for **Fossibot**, install it
 4. Restart Home Assistant
 
 ### Manual
 
-1. Download this repository
-2. Copy the `custom_components/fossibot-ha` folder to `<config>/custom_components/fossibot-ha`
-3. Restart Home Assistant
+1. Copy `custom_components/fossibot-ha` into `<config>/custom_components/`
+2. Restart Home Assistant
 
-## Setup
+## Configuration
 
-### 1. Configure Local MQTT in BrightEMS
+### 1. Point the device at your broker
 
-1. Open the **BrightEMS** app (v1.6.0+)
-2. Go to **Me** > **Settings** > **Local MQTT Broker Settings**
-3. Enter your local MQTT broker host address
-4. Copy your **API Token** (you'll need it for the integration)
-5. Make sure your MQTT broker is reachable on **port 1883** from your devices
+In the **BrightEMS** app: **Me** → **Settings** → **Local MQTT Broker Settings**.
+Enter your broker's host address, then copy the **API Token** shown on that
+screen — you need it in the next step.
 
-> **Important:** The master account (first to bind the device) is required to configure MQTT settings. All users sharing devices must use the same broker host.
+> Only the **master account** (whoever bound the device first) can change MQTT
+> settings. Everyone sharing the device must use the same broker host.
 
-### 2. Add the Integration in Home Assistant
+### 2. Add the integration
 
-1. Go to **Settings** > **Devices & Services**
-2. Click **+ Add Integration** and search for **Fossibot**
-3. Enter:
-   - **API Token** — from the BrightEMS app settings
-   - **MQTT Broker Host** — your local MQTT broker address
-   - **MQTT Broker Port** — default `1883`
-   - **MQTT Username** — optional, depends on your broker configuration
-4. Click Submit
+**Settings** → **Devices & Services** → **+ Add Integration** → **Fossibot**:
 
-The integration will fetch your device list, connect to your MQTT broker, and create all entities automatically.
+| Field | Value |
+|-------|-------|
+| **API Token** | from the BrightEMS screen above |
+| **MQTT Broker Host** | your broker's address |
+| **MQTT Broker Port** | `1883` |
+| **MQTT Username** | optional — only if your broker requires it |
+
+The integration fetches your device list, connects to the broker and creates
+every entity automatically.
+
+### Upgrading to v3.0
+
+No reconfiguration needed — restart Home Assistant and the new entities appear.
+Three things change behaviour:
+
+- **Discharge Lower Limit is now 0–50% and AC Charging Upper Limit is 60–100%**,
+  matching the vendor specification. If you had either set outside those
+  ranges, the device keeps its current value but you can no longer set a new
+  one outside the documented range. See
+  [Writing to your device](#writing-to-your-device).
+- **"Maximum Charging Current" is now "DC Input Charging Current Limit"** — it
+  always controlled the DC (solar / vehicle) input, not the AC one. The entity
+  ID is unchanged, so automations keep working.
+- **LED Mode reports the real mode from the device** instead of remembering the
+  last option it set, so it can now show SOS and Flash, and it stays correct
+  when the mode is changed on the unit itself.
+
+Grid frequency also reads correctly now — earlier versions could report it
+around 0.5 Hz.
 
 ### Upgrading from v1.x
 
-Version 2.0 replaces the cloud-based connection with local MQTT. You must **remove and re-add** the integration after upgrading:
-
-1. Go to **Settings** > **Devices & Services**
-2. Remove the existing Fossibot integration
-3. Re-add it with your new MQTT broker settings and API token
+v2.0 replaced the cloud connection with local MQTT, so the config entry format
+changed. **Remove the integration and re-add it** with your broker settings and
+API token.
 
 ## Entities
 
-### Sensors (read-only)
+**107 entities per device, 55 enabled by default.** The rest — individual port
+powers, BMS internals, static capability values — are created but disabled, so
+a device page is not buried under two dozen mostly-zero readings. Enable any of
+them from the device page when you actually need it.
 
-| Entity | Unit | Description |
-|--------|------|-------------|
-| State of Charge | % | Main battery SoC |
-| State of Charge Slave 1 | % | Expansion battery 1 SoC |
-| State of Charge Slave 2 | % | Expansion battery 2 SoC |
-| DC Input | W | Solar / DC input power |
-| Total Input | W | Combined input power |
-| AC Charging Rate | — | Current AC charging rate knob position |
-| Total Output | W | Combined output power |
-| AC Output Voltage | V | AC output voltage |
-| AC Output Frequency | Hz | AC output frequency |
-| AC Input Voltage | V | AC input voltage |
-| AC Input Frequency | Hz | AC input frequency |
+Rows marked **†** are the disabled-by-default ones.
 
-### Switches (on/off)
+### Sensors
+
+**Battery**
+
+| Entity | Unit | Notes |
+|--------|------|-------|
+| State of Charge | % | Main pack |
+| State of Charge Slave 1 – 4 | % | One per connected expansion battery |
+| Battery Usable Capacity | Ah | As reported by the BMS |
+| Average Charge SoC / Average Discharge SoC | % | Diagnostic |
+| Battery Chemistry † | — | Capacity and cell topology in the attributes |
+
+**Power in**
+
+| Entity | Unit | Notes |
+|--------|------|-------|
+| AC Input | W | Charging from mains |
+| DC Input | W | Solar / DC input |
+| USB-C Input | W | Charging over USB-C |
+| Total Input | W | All sources combined |
+
+**Power out**
+
+| Entity | Unit | Notes |
+|--------|------|-------|
+| Total Output | W | Everything combined |
+| AC Output Power | W | |
+| Inverter Output Power | W | Off-grid inverter |
+| Inverter Apparent Power † | VA | |
+| USB 1–3, QC 1–3, PD 1–5 Power † | W | Per-port breakdown |
+| XT60, Cigarette Socket, DC 5521 Power † | W | Per-port breakdown |
+| Wireless Charging Power †, LED Power † | W | |
+
+**Electrical**
+
+| Entity | Unit | Notes |
+|--------|------|-------|
+| AC Output Voltage / Frequency | V / Hz | Inverter side |
+| AC Input Voltage / Frequency | V / Hz | Grid side |
+
+**Energy and time**
+
+| Entity | Unit | Notes |
+|--------|------|-------|
+| PV Energy Total | kWh | Lifetime total — ready for the Energy dashboard |
+| Remaining Charge Time | min | BMS estimate to full |
+| Remaining Discharge Time | min | BMS estimate to empty |
+| Charge Schedule Remaining † | min | Time left on a scheduled charge |
+
+**Diagnostic**
+
+| Entity | Unit | Notes |
+|--------|------|-------|
+| Active Faults | count | Every decoded fault name is in the attributes |
+| AC Charging Rate Active † | — | The level the device is really running at |
+| AC Charge Max Power †, DC Input Max Power † | W | Device ratings |
+| DC Input Max Current † | A | The ceiling the current-limit slider obeys |
+| DC Input Min / Max Voltage † | V | Accepted DC input window |
+| Protocol Version † | — | Should be `0` or `1` on a power station |
+
+### Binary sensors
+
+| Entity | Notes |
+|--------|-------|
+| **Fault** | `problem` class — on whenever any fault bit is set, names in the attributes |
+| Grid Charging | Mains is actively charging |
+| Grid Input Present | Mains detected |
+| On Grid | The device's own on-grid / off-grid determination — not the same as mains being present |
+| DC Charging / DC Input Present | Solar or DC input |
+| AC Inverter Output | The inverter is actually running |
+| DC Port Output | The DC section is powered |
+| ECO Mode | |
+| Battery Charging | Diagnostic |
+| PV High Voltage Charging † / Present † | High-voltage PV input |
+| Car Charging † / Car Charge Input Present † | Vehicle charging input |
+| Wireless Charging Active † | |
+| USB 1–2, QC 1–2, PD 1–5, XT60, Cigarette Socket, DC 5521, LED † | Individual port state |
+| Battery Discharging †, Fully Charged †, Fully Discharged †, Overvoltage †, Balancing † | BMS state |
+| Precharge / Charge / Discharge MOSFET On † | BMS internals |
+
+### Switches
 
 | Entity | Description |
 |--------|-------------|
-| USB Output | Toggle USB ports |
-| DC Output | Toggle DC output |
-| AC Output | Toggle AC inverter |
-| AC Silent Charging | Toggle silent charging mode |
+| USB Output | Toggle the USB ports |
+| DC Output | Toggle the DC output |
+| AC Output | Toggle the AC inverter |
+| AC Silent Charging | Quieter, slower mains charging |
+| Buzzer | Device beeper |
+| Grid Mode AC Auto Output | Enable AC output automatically when mains appears |
+| App Remote Shutdown | Allow the unit to be shut down remotely |
+| Low Battery Notification | Enable the low-battery alert |
 
-### Selects (dropdown)
+### Selects
 
 | Entity | Options |
 |--------|---------|
-| LED Mode | Off, On, SOS, Flash |
-| USB Standby Time | Off, 3 min, 5 min, 10 min, 30 min |
-| AC Standby Time | Off, 8 hours, 16 hours, 24 hours |
-| DC Standby Time | Off, 8 hours, 16 hours, 24 hours |
-| Screen Rest Time | Off, 3 min, 5 min, 10 min, 30 min |
-| Sleep Time | 5 min, 10 min, 30 min, 8 hours |
+| LED Mode | Off · On · SOS · Flash |
+| AC Charging Rate | Level 1 – 5 |
+| DC Input Type | MPPT (PV) · DC source |
+| USB Standby Time | Off · 3 min · 5 min · 10 min · 30 min |
+| AC Standby Time | Off · 8 h · 16 h · 24 h |
+| DC Standby Time | Off · 8 h · 16 h · 24 h |
+| Screen Rest Time | Off · 3 min · 5 min · 10 min · 30 min |
+| Sleep Time | 5 min · 10 min · 30 min · 8 h |
 
-### Numbers (slider / input)
+### Numbers
 
 | Entity | Range | Unit | Description |
 |--------|-------|------|-------------|
-| Maximum Charging Current | 1–20 | A | AC charging current limit |
-| Stop Charge After | 0–1440 | min | Auto-stop charging timer (0 = off) |
-| Discharge Lower Limit | 0–100 | % | Minimum SoC before output cutoff |
-| AC Charging Upper Limit | 0–100 | % | Maximum SoC to charge to |
+| DC Input Charging Current Limit | 1 – 20 | A | DC (solar / vehicle) charging current. The slider also narrows itself to whatever your device reports as its own maximum |
+| Stop Charge After | 0 – 5000 | min | Scheduled charge duration; `0` disables it |
+| Discharge Lower Limit | 0 – 50 | % | Stop discharging at this SoC |
+| AC Charging Upper Limit | 60 – 100 | % | Stop charging at this SoC |
+| Wi-Fi Upload Interval | 5 – 3600 | s | How often the device pushes data by itself |
+| Low Battery Notification Threshold | 0 – 100 | % | Alert threshold |
 
-## Architecture
+Home Assistant also polls every 30 s independently of the upload interval, so
+the two together decide how fresh the data is.
 
-```
-custom_components/fossibot-ha/
-  __init__.py          # Integration setup, platform loading
-  config_flow.py       # UI-based configuration
-  coordinator.py       # DataUpdateCoordinator (polling loop)
-  entity.py            # FossibotEntity base class
-  sensor.py            # 11 sensor entities (data-driven)
-  switch.py            # 4 switch entities (data-driven)
-  select.py            # 6 select entities (data-driven)
-  number.py            # 4 number entities (data-driven)
-  sydpower/
-    api_client.py      # REST API (device list, state sync)
-    mqtt_client.py     # MQTT over TCP (paho-mqtt)
-    connector.py       # Connection orchestration
-    modbus.py          # Modbus encoding, CRC-16, safety validation
-    const.py           # API endpoints, register addresses
-    logger.py          # Rate-limited smart logger
-```
+## Writing to your device
 
-**Key design decisions:**
-- All entity definitions are data-driven (lists of dicts) — no per-entity boilerplate
-- `WRITABLE_REGISTERS` safety map in `modbus.py` defines the exact set of allowed values per register, preventing accidental writes that could brick a device
-- Device online/offline state is synced with the SYDPOWER platform via `pub_updateMqttState` API
-- Per-device `modbus_address` is extracted from the API rather than assumed
+**This firmware does not validate register writes.** A value outside the
+documented range can permanently brick the unit. That is not a theoretical
+concern, so every write in this integration is checked against an allowlist of
+values taken from the vendor specification, and a write that is not on the list
+is refused before it reaches the broker.
 
-## Debugging
+Consequences worth knowing about:
 
-Enable debug logging in `configuration.yaml`:
+- **The SoC sliders match the specification, not the full 0–100%.** The
+  discharge floor is documented as 0–50% and the charge ceiling as 60–100%.
+  Versions before 3.0 offered 0–100% for both, which was out of range.
+- **Destructive and vendor-only registers are unreachable by design** — factory
+  reset, debug mode, chip-type selector and timezone have no entity, and the
+  code refuses them explicitly with a stated reason rather than by omission.
+- **Firmware updates are not implemented.** Use the BrightEMS app.
+
+If you think a range is wrong, the reasoning for each one is in
+[docs/PROTOCOL_AUDIT.md](docs/PROTOCOL_AUDIT.md) with the register it came
+from — please open an issue rather than widening the allowlist locally.
+
+## Troubleshooting
+
+### Enable debug logging
+
+In `configuration.yaml`:
 
 ```yaml
 logger:
   default: info
   logs:
-    custom_components.fossibot: debug
+    custom_components.fossibot-ha: debug
 ```
 
-## Limitations
+The logger name follows the **folder** name (`fossibot-ha`), not the
+integration domain (`fossibot`).
 
-- Requires internet for the initial device list fetch and state sync API calls (`api.app.sydpower.com`)
-- MQTT communication itself is fully local
-- Slave battery SoC sensors only appear when expansion batteries are connected and report non-zero values
-- API token must be regenerated if compromised (via BrightEMS app settings)
+### Common problems
 
-## Contributing
+**Entities are all "unavailable" right after setup.**
+The power station sleeps aggressively. The integration accepts the broker
+connection anyway and recovers on its own once the device answers — wake the
+unit by pressing a button on it, or wait for the next poll.
 
-Contributions are welcome — both issues and pull requests. If you have a Fossibot model not listed above, please share your results on Discord or GitHub Issues.
+**A device is missing from Home Assistant.**
+The device list comes from the SYDPOWER API. If a device has no `device_id`
+there, it is skipped and logged with a warning; re-registering it in BrightEMS
+fixes it.
+
+**The integration loads but nothing ever updates.**
+The device has to reach *your* broker. Check that the host you typed into
+BrightEMS is reachable from the device's network, and that port 1883 is open to
+it — Home Assistant being able to reach the broker is not sufficient.
+
+**Slave battery sensors read "unknown".**
+Expected when no expansion battery is attached; the register reports "not
+connected" and the sensor stays empty rather than showing 0%.
+
+## Not supported
+
+- **Balcony grid-tie inverters.** These use protocol V1/V2, which reuses the
+  same register numbers for entirely different values — holding register 41 is
+  the battery pack layout on a power station and a grid-charge time window on
+  an inverter. Supporting both needs a protocol-selected register profile;
+  [docs/PROTOCOL_AUDIT.md](docs/PROTOCOL_AUDIT.md#not-implemented) lists what
+  it would add.
+- **Firmware updates** (Modbus function `0x26`) — documented, deliberately not
+  implemented. A failed flash bricks hardware.
+- **Wi-Fi provisioning** (function 7) — belongs to onboarding, which is the
+  app's job.
+- **Smart sockets and smart meters** — V1/V2 accessories.
+- **Power/energy history charts** — V2 only.
+
+## For contributors
+
+```
+custom_components/fossibot-ha/
+  __init__.py          # Setup, platform loading
+  config_flow.py       # UI configuration
+  coordinator.py       # DataUpdateCoordinator, health check, reconnection
+  entity.py            # Base entity + device registry info
+  sensor.py            # ─┐
+  binary_sensor.py     #  │ entity tables (plain lists of dicts)
+  switch.py            #  │
+  select.py            #  │
+  number.py            # ─┘
+  sydpower/
+    const.py           # Register addresses, protocol enumerations
+    registers.py       # V0 register map: decoders, bitfields, fault tables
+    modbus.py          # Framing, CRC-16, write allowlist
+    connector.py       # Connection orchestration
+    mqtt_client.py     # MQTT over TCP (paho-mqtt)
+    api_client.py      # REST API (device list, state sync)
+    logger.py          # Rate-limited logger
+```
+
+The shape of the code follows a few decisions:
+
+- **The register map is data, not code.** `registers.py` holds the decoders,
+  bitfield tables and fault names, each annotated with the protocol section it
+  came from, so a mapping can be checked against the document without reading
+  any logic.
+- **Entity definitions are plain lists of dicts.** Adding a sensor is one line;
+  there is no per-entity class.
+- **Decoding is index-driven.** Each field is read if the response is long
+  enough to hold it, so a response of unexpected length still yields
+  everything it does contain instead of being discarded.
+- **The tests import the live entity tables** (`tests/conftest.py` stubs Home
+  Assistant for this) and check them against the protocol layer. Every number
+  slider is walked from minimum to maximum and each step asserted to encode to
+  an allowed value, so a UI bound the allowlist would reject fails a test
+  instead of reaching hardware.
+
+Run the tests with:
+
+```bash
+python -m pytest tests/ -q
+```
+
+Contributions are welcome. If you have a model that is not in the table above,
+sharing your results is genuinely useful — the compatibility list is built from
+user reports.
+
+## Thank you, Sydpower
+
+This integration began as reverse engineering. It no longer has to be.
+
+The **Sydpower technical team** reached out and shared their complete Modbus
+protocol documentation — the full holding and input register maps, the fault
+and status bitfields, the value ranges and unit scalings, and the firmware
+upgrade specification. They did that voluntarily, for an unofficial
+community project, with nothing asked in return.
+
+That changed the quality of this integration in ways guessing never could:
+
+- Faults are now reported by name instead of being silently discarded, because
+  the documentation says what each of the eight fault words means — including
+  which bits are normal operating state and must *not* be raised as alarms.
+- Write ranges come from the specification rather than from whatever the app
+  happened to offer. Two of the sliders had been able to write values outside
+  the documented range, on firmware that does not validate writes. Nobody
+  would have found that without the ranges in writing.
+- Values that were subtly wrong — grid frequency, a mislabelled charging
+  current — could be corrected against a source of truth instead of being
+  argued about.
+- Half of the device status field turned out to live in a register nobody knew
+  to read.
+
+A vendor helping the people who own their hardware understand it better is
+rare, and worth saying out loud. **Thank you.**
 
 ## Credits
 
-Created by [@iamslan](https://github.com/iamslan) and [@alessandro-lac](https://github.com/alessandro-lac), based on reverse engineering the BrightEMS app's communication patterns.
+Created by [@iamslan](https://github.com/iamslan) and
+[@alessandro-lac](https://github.com/alessandro-lac), originally by reverse
+engineering the BrightEMS app, and now built on the official protocol
+specification provided by Sydpower.
 
 ## License
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,79 +1,123 @@
 """Pytest configuration for Fossibot tests.
 
-Rewrites sydpower's relative imports so the package can be tested
-without installing it or Home Assistant.
+The integration lives in ``custom_components/fossibot-ha``, whose hyphen makes
+it un-importable as a package name, and its modules import Home Assistant and
+the MQTT/HTTP client libraries. This module
+
+* registers the integration as a top-level package named ``fossibot_ha``, and
+* installs lightweight stubs for ``homeassistant``, ``paho`` and ``aiohttp``,
+
+so the tests can import the *real* entity-definition tables rather than
+maintaining hand-written copies of them (copies which silently drift out of
+sync with the code they are meant to protect).
 """
 
 import importlib
+import importlib.util
 import sys
+import types
 from pathlib import Path
-from unittest.mock import MagicMock
 
-# Point directly at the integration package
-INTEGRATION_DIR = Path(__file__).resolve().parent.parent / "custom_components" / "fossibot-ha"
+INTEGRATION_DIR = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "fossibot-ha"
+)
 
-# Stub out homeassistant so that importing entity.py / const.py doesn't blow up
-ha_mock = MagicMock()
-for mod in [
+
+# ---------------------------------------------------------------------------
+# Stub framework
+#
+# Home Assistant is used two ways by the platform modules: as base classes
+# (``SensorEntity``) and as enum-like constant holders
+# (``SensorDeviceClass.POWER``). A MagicMock covers the second but not the
+# first — you cannot subclass a Mock. So each stub attribute is a freshly
+# created class, cached by name so repeated access is identity-stable and
+# distinct names stay distinct.
+# ---------------------------------------------------------------------------
+
+class _StubMeta(type):
+    """Metaclass that materialises any attribute as a nested stub class."""
+
+    def __getattr__(cls, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        stub = _StubMeta(name, (), {})
+        setattr(cls, name, stub)
+        return stub
+
+
+class _StubModule(types.ModuleType):
+    """Module whose every attribute is a stub class."""
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        stub = _StubMeta(name, (), {})
+        setattr(self, name, stub)
+        return stub
+
+
+_STUBBED_MODULES = [
     "homeassistant",
-    "homeassistant.core",
-    "homeassistant.config_entries",
-    "homeassistant.const",
-    "homeassistant.helpers",
-    "homeassistant.helpers.update_coordinator",
     "homeassistant.components",
+    "homeassistant.components.binary_sensor",
+    "homeassistant.components.number",
+    "homeassistant.components.select",
     "homeassistant.components.sensor",
     "homeassistant.components.switch",
-    "homeassistant.components.select",
-    "homeassistant.helpers.entity_platform",
+    "homeassistant.config_entries",
+    "homeassistant.const",
+    "homeassistant.core",
     "homeassistant.data_entry_flow",
     "homeassistant.exceptions",
+    "homeassistant.helpers",
+    "homeassistant.helpers.entity",
+    "homeassistant.helpers.entity_platform",
+    "homeassistant.helpers.update_coordinator",
     "voluptuous",
-]:
-    sys.modules.setdefault(mod, ha_mock)
+    "aiohttp",
+    "paho",
+    "paho.mqtt",
+    "paho.mqtt.client",
+]
 
-# Register the integration as a top-level package named "fossibot_ha"
-# so that `from fossibot_ha.sydpower.modbus import ...` works.
-if "fossibot_ha" not in sys.modules:
-    sys.path.insert(0, str(INTEGRATION_DIR.parent))
-    # Python doesn't allow hyphens in package names, so we create an alias
-    spec = importlib.util.spec_from_file_location(
-        "fossibot_ha",
-        INTEGRATION_DIR / "__init__.py",
-        submodule_search_locations=[str(INTEGRATION_DIR)],
-    )
-    pkg = importlib.util.module_from_spec(spec)
-    sys.modules["fossibot_ha"] = pkg
+for _name in _STUBBED_MODULES:
+    if _name not in sys.modules:
+        sys.modules[_name] = _StubModule(_name)
 
-    # Also register sydpower sub-package
-    sydpower_dir = INTEGRATION_DIR / "sydpower"
-    sydpower_spec = importlib.util.spec_from_file_location(
-        "fossibot_ha.sydpower",
-        sydpower_dir / "__init__.py",
-        submodule_search_locations=[str(sydpower_dir)],
-    )
-    sydpower_pkg = importlib.util.module_from_spec(sydpower_spec)
-    sys.modules["fossibot_ha.sydpower"] = sydpower_pkg
+# Decorators must stay callable and identity-preserving; a stub class would be
+# invoked as ``callback(func)`` and fail.
+sys.modules["homeassistant.core"].callback = lambda func: func
 
-    # Now load const (no HA deps)
-    const_spec = importlib.util.spec_from_file_location(
-        "fossibot_ha.sydpower.const",
-        sydpower_dir / "const.py",
-    )
-    const_mod = importlib.util.module_from_spec(const_spec)
-    sys.modules["fossibot_ha.sydpower.const"] = const_mod
-    const_spec.loader.exec_module(const_mod)
 
-    # Patch sydpower's relative import: when modbus.py does
-    # `from .const import ...` it resolves to fossibot_ha.sydpower.const
-    sydpower_pkg.const = const_mod
+def _register_package(name: str, directory: Path) -> None:
+    """Register ``directory`` as an importable package under ``name``.
 
-    # Now load modbus
-    modbus_spec = importlib.util.spec_from_file_location(
-        "fossibot_ha.sydpower.modbus",
-        sydpower_dir / "modbus.py",
-    )
-    modbus_mod = importlib.util.module_from_spec(modbus_spec)
-    sys.modules["fossibot_ha.sydpower.modbus"] = modbus_mod
-    modbus_spec.loader.exec_module(modbus_mod)
-    sydpower_pkg.modbus = modbus_mod
+    The package's own ``__init__.py`` is deliberately not executed — for the
+    integration root it would pull in the Home Assistant setup path — but
+    ``__path__`` is set so that relative imports inside the package resolve
+    normally through the standard import machinery.
+    """
+    if name in sys.modules:
+        return
+    package = types.ModuleType(name)
+    package.__path__ = [str(directory)]
+    sys.modules[name] = package
+
+
+_register_package("fossibot_ha", INTEGRATION_DIR)
+_register_package("fossibot_ha.sydpower", INTEGRATION_DIR / "sydpower")
+
+# Import eagerly so a syntax or import error surfaces during collection
+# rather than as a confusing failure inside an individual test.
+for _module in (
+    "fossibot_ha.sydpower.const",
+    "fossibot_ha.sydpower.registers",
+    "fossibot_ha.sydpower.modbus",
+    "fossibot_ha.entity",
+    "fossibot_ha.binary_sensor",
+    "fossibot_ha.sensor",
+    "fossibot_ha.select",
+    "fossibot_ha.switch",
+    "fossibot_ha.number",
+):
+    importlib.import_module(_module)

--- a/tests/test_entity_definitions.py
+++ b/tests/test_entity_definitions.py
@@ -1,104 +1,117 @@
-"""Tests for entity definitions: sensor, switch, select, number coverage and command completeness.
+"""Tests for entity definitions across the sensor, binary_sensor, switch,
+select and number platforms.
 
 These verify that:
-- Every parsed data key has a corresponding entity definition
-- Every command referenced by switches/selects exists in the connector's COMMANDS dict
-- Every writable register has a controllable entity (number, select, or switch)
-- No duplicate unique_id patterns exist
-"""
+- Every key ``parse_registers`` emits is either exposed by an entity or
+  explicitly accounted for as attribute-only / internal
+- Every command a switch references exists in the connector's COMMANDS dict
+- Every writable register is reachable from a controllable entity
+- Every select option and number bound is accepted by WRITABLE_REGISTERS
+- unique_id suffixes do not collide across platforms
 
-import pytest
+The definitions are imported from the platform modules themselves (see
+``conftest.py`` for the Home Assistant stubs that makes that possible), so a
+change to an entity table is checked against the protocol layer rather than
+against a hand-written copy that can silently drift.
+"""
 
 from fossibot_ha.sydpower.modbus import (
     WRITABLE_REGISTERS,
     parse_registers,
 )
+from fossibot_ha.sydpower.connector import COMMANDS as CONNECTOR_COMMANDS
 from fossibot_ha.sydpower.const import (
-    REGISTER_MAXIMUM_CHARGING_CURRENT,
-    REGISTER_USB_OUTPUT, REGISTER_DC_OUTPUT, REGISTER_AC_OUTPUT,
-    REGISTER_LED, REGISTER_AC_SILENT_CHARGING,
-    REGISTER_USB_STANDBY_TIME, REGISTER_AC_STANDBY_TIME,
-    REGISTER_DC_STANDBY_TIME, REGISTER_SCREEN_REST_TIME,
-    REGISTER_STOP_CHARGE_AFTER, REGISTER_DISCHARGE_LIMIT,
-    REGISTER_CHARGING_LIMIT, REGISTER_SLEEP_TIME,
+    REGISTER_AC_OUTPUT,
+    REGISTER_AC_SILENT_CHARGING,
+    REGISTER_DC_OUTPUT,
+    REGISTER_LED,
+    REGISTER_USB_OUTPUT,
 )
 
+from fossibot_ha.binary_sensor import BINARY_SENSOR_DEFINITIONS
+from fossibot_ha.number import NUMBER_DEFINITIONS
+from fossibot_ha.select import SELECT_DEFINITIONS
+from fossibot_ha.sensor import SENSOR_DEFINITIONS
+from fossibot_ha.switch import (
+    REGISTER_SWITCH_DEFINITIONS,
+    SWITCH_DEFINITIONS,
+)
 
-# ---------------------------------------------------------------------------
-# Inline definitions (mirroring the entity platform files)
-#
-# We can't import the actual HA entity files because they depend on
-# homeassistant imports. Instead, we replicate the definition dicts
-# and test invariants against the modbus layer.
-# ---------------------------------------------------------------------------
+SENSOR_KEYS = [d["key"] for d in SENSOR_DEFINITIONS]
+BINARY_SENSOR_KEYS = [d["key"] for d in BINARY_SENSOR_DEFINITIONS]
+SWITCH_KEYS = [d["key"] for d in SWITCH_DEFINITIONS]
+REGISTER_SWITCH_KEYS = [d["key"] for d in REGISTER_SWITCH_DEFINITIONS]
+SELECT_KEYS = [d["key"] for d in SELECT_DEFINITIONS]
+NUMBER_KEYS = [d["key"] for d in NUMBER_DEFINITIONS]
 
-# sensor.py — read-only sensors
-SENSOR_KEYS = [
-    "soc", "soc_s1", "soc_s2",
-    "dcInput", "totalInput", "acChargingRate", "totalOutput",
-    "acOutputVoltage", "acOutputFrequency", "acInputVoltage", "acInputFrequency",
-]
 
-# switch.py — boolean on/off entities
-SWITCH_DEFINITIONS = [
-    {"name": "USB Output", "key": "usbOutput", "on_command": "REGEnableUSBOutput", "off_command": "REGDisableUSBOutput"},
-    {"name": "DC Output", "key": "dcOutput", "on_command": "REGEnableDCOutput", "off_command": "REGDisableDCOutput"},
-    {"name": "AC Output", "key": "acOutput", "on_command": "REGEnableACOutput", "off_command": "REGDisableACOutput"},
-    {"name": "AC Silent Charging", "key": "acSilentCharging", "on_command": "REGEnableACSilentChg", "off_command": "REGDisableACSilentChg"},
-]
-
-# select.py — LED mode (command-based)
-LED_MODES = {
-    "Off": "REGDisableLED",
-    "On": "REGEnableLEDAlways",
-    "SOS": "REGEnableLEDSOS",
-    "Flash": "REGEnableLEDFlash",
+# Keys that are decoded but deliberately have no entity of their own.
+# Each must have a stated reason, so that adding a decoded field without
+# deciding how to surface it fails this test rather than passing silently.
+UNEXPOSED_KEYS = {
+    # Shown as attributes of the fault sensors.
+    "faults": "attribute of the Active Faults / Fault entities",
+    "faultsAc": "attribute of the Active Faults / Fault entities",
+    "faultsPv": "attribute of the Active Faults / Fault entities",
+    "faultsBms": "attribute of the Active Faults / Fault entities",
+    "faultsPanel": "attribute of the Active Faults / Fault entities",
+    # Shown as attributes of the Battery Chemistry sensor.
+    "batteryCapacityAh": "attribute of the Battery Chemistry sensor",
+    "batteryCellsSeries": "attribute of the Battery Chemistry sensor",
+    "batteryCellsParallel": "attribute of the Battery Chemistry sensor",
+    # Raw backing values for a select's decoded state.
+    "lightModeRaw": "backs the LED Mode select",
+    "dcInputTypeRaw": "backs the DC Input Type select",
+    "lightMode": "human-readable form of lightModeRaw",
+    "dcInputType": "human-readable form of dcInputTypeRaw",
+    # Raw 32-bit field; every meaningful bit has its own binary sensor.
+    "systemStateRaw": "decomposed into individual binary sensors",
+    # Surfaced through the device registry rather than as entities.
+    "serialNumber": "device_info serial_number",
+    "versionAcHardware": "device_info hw_version",
+    "versionBmsHardware": "device_info hw_version",
+    "versionPvHardware": "device_info hw_version",
+    "versionPanelHardware": "device_info hw_version",
+    "versionExternalComHardware": "device_info hw_version",
+    "versionAcSoftware": "device_info sw_version",
+    "versionBmsSoftware": "device_info sw_version",
+    "versionPvSoftware": "device_info sw_version",
+    "versionPanelSoftware": "device_info sw_version",
+    "versionExternalComSoftware": "device_info sw_version",
+    "deviceMarketType": "device_info model",
+    "deviceModelCode": "device_info model",
+    # Static hardware descriptors with no actionable use yet.
+    "deviceVoltageType": "static hardware descriptor",
+    "deviceFrequencyType": "static hardware descriptor",
+    "wirelessModules": "static hardware descriptor",
+    "storageFlag": "internal device data-storage flag",
 }
 
-# select.py — register-based selects (discrete option sets)
-REGISTER_SELECT_KEYS = [
-    {"key": "usbStandbyTime", "register": REGISTER_USB_STANDBY_TIME, "options_count": 5},
-    {"key": "acStandbyTime", "register": REGISTER_AC_STANDBY_TIME, "options_count": 4},
-    {"key": "dcStandbyTime", "register": REGISTER_DC_STANDBY_TIME, "options_count": 4},
-    {"key": "screenRestTime", "register": REGISTER_SCREEN_REST_TIME, "options_count": 5},
-    {"key": "wholeMachineUnusedTime", "register": REGISTER_SLEEP_TIME, "options_count": 4},
-]
-
-# number.py — continuous range entities
-NUMBER_DEFINITIONS = [
-    {"key": "maximumChargingCurrent", "register": REGISTER_MAXIMUM_CHARGING_CURRENT, "min": 1, "max": 20},
-    {"key": "stopChargeAfter", "register": REGISTER_STOP_CHARGE_AFTER, "min": 0, "max": 1440},
-    {"key": "dischargeLowerLimit", "register": REGISTER_DISCHARGE_LIMIT, "min": 0, "max": 100},
-    {"key": "acChargingUpperLimit", "register": REGISTER_CHARGING_LIMIT, "min": 0, "max": 100},
-]
-
-# Connector COMMANDS dict (pre-defined byte sequences)
-CONNECTOR_COMMANDS = {
-    "REGRequestSettings",
-    "REGDisableUSBOutput", "REGEnableUSBOutput",
-    "REGDisableDCOutput", "REGEnableDCOutput",
-    "REGDisableACOutput", "REGEnableACOutput",
-    "REGDisableLED", "REGEnableLEDAlways",
-    "REGEnableLEDSOS", "REGEnableLEDFlash",
-    "REGDisableACSilentChg", "REGEnableACSilentChg",
-}
-
 
 # ---------------------------------------------------------------------------
-# Full entity coverage: every parse_registers key has an entity
+# Full entity coverage: every parse_registers key is accounted for
 # ---------------------------------------------------------------------------
 
 class TestEntityCoverage:
-    """Every key emitted by parse_registers should have a corresponding entity."""
+    """Every key emitted by parse_registers should be exposed or explained."""
 
     @staticmethod
     def _all_parsed_keys():
-        """Collect every key that parse_registers can produce."""
+        """Collect every key parse_registers can produce.
+
+        The register array is filled so that optional fields (slave
+        batteries, PV energy counter, packed identity words) all decode.
+        """
         keys = set()
         regs = [0] * 81
-        regs[41] = 0xFFFF  # all outputs on
-        regs[53] = 100     # slave 1 present
-        regs[55] = 100     # slave 2 present
+        for index in range(81):
+            regs[index] = 0x0101
+        regs[41] = 0xFFFF          # every system-state high bit set
+        regs[42] = 0xFFFF          # every system-state low bit set
+        for slave in (53, 55, 66, 67):
+            regs[slave] = 500      # slave batteries present
+        for index in range(72, 80):
+            regs[index] = 0x4142   # printable serial-number characters
         keys.update(parse_registers(regs, "device/response/client/04").keys())
         keys.update(parse_registers(regs, "device/response/client/data").keys())
         return keys
@@ -106,33 +119,70 @@ class TestEntityCoverage:
     @staticmethod
     def _all_entity_keys():
         """Collect all data keys covered by any entity type."""
-        keys = set(SENSOR_KEYS)
-        keys.update(d["key"] for d in SWITCH_DEFINITIONS)
-        keys.add("ledOutput")  # LED mode select
-        keys.update(d["key"] for d in REGISTER_SELECT_KEYS)
-        keys.update(d["key"] for d in NUMBER_DEFINITIONS)
-        return keys
+        return (
+            set(SENSOR_KEYS)
+            | set(BINARY_SENSOR_KEYS)
+            | set(SWITCH_KEYS)
+            | set(REGISTER_SWITCH_KEYS)
+            | set(SELECT_KEYS)
+            | set(NUMBER_KEYS)
+        )
 
     def test_all_parsed_keys_have_entities(self):
-        parsed = self._all_parsed_keys()
-        entities = self._all_entity_keys()
-        missing = parsed - entities
+        missing = self._all_parsed_keys() - self._all_entity_keys()
+        missing -= set(UNEXPOSED_KEYS)
         assert missing == set(), (
-            "Keys from parse_registers with no entity: %s" % missing
+            "Decoded keys with neither an entity nor an UNEXPOSED_KEYS "
+            "entry: %s" % sorted(missing)
+        )
+
+    def test_unexposed_keys_are_actually_decoded(self):
+        """UNEXPOSED_KEYS should not accumulate entries for dead fields."""
+        stale = set(UNEXPOSED_KEYS) - self._all_parsed_keys()
+        assert stale == set(), (
+            "UNEXPOSED_KEYS lists keys parse_registers never emits: %s"
+            % sorted(stale)
+        )
+
+    def test_no_entity_references_an_undecoded_key(self):
+        unknown = self._all_entity_keys() - self._all_parsed_keys()
+        assert unknown == set(), (
+            "Entities bound to keys parse_registers never emits: %s"
+            % sorted(unknown)
         )
 
     def test_no_entity_key_collisions(self):
-        """No key should be claimed by multiple entity types."""
-        sensor_keys = set(SENSOR_KEYS)
-        switch_keys = {d["key"] for d in SWITCH_DEFINITIONS}
-        select_keys = {"ledOutput"} | {d["key"] for d in REGISTER_SELECT_KEYS}
-        number_keys = {d["key"] for d in NUMBER_DEFINITIONS}
+        """A key should be claimed by exactly one platform."""
+        groups = {
+            "sensor": set(SENSOR_KEYS),
+            "binary_sensor": set(BINARY_SENSOR_KEYS),
+            "switch": set(SWITCH_KEYS) | set(REGISTER_SWITCH_KEYS),
+            "select": set(SELECT_KEYS),
+            "number": set(NUMBER_KEYS),
+        }
+        seen: dict[str, str] = {}
+        collisions = []
+        for platform, keys in groups.items():
+            for key in keys:
+                if key in seen:
+                    collisions.append((key, seen[key], platform))
+                seen[key] = platform
+        assert collisions == [], "Keys claimed by two platforms: %s" % collisions
 
-        all_groups = [sensor_keys, switch_keys, select_keys, number_keys]
-        all_keys = []
-        for g in all_groups:
-            all_keys.extend(g)
-        assert len(all_keys) == len(set(all_keys)), "Duplicate key across entity types"
+    def test_no_unique_id_collisions(self):
+        """unique_id suffixes must be distinct across every platform."""
+        suffixes = (
+            SENSOR_KEYS
+            + BINARY_SENSOR_KEYS
+            + SWITCH_KEYS
+            + REGISTER_SWITCH_KEYS
+            + NUMBER_KEYS
+            + [d.get("unique_id_suffix") or d["key"] for d in SELECT_DEFINITIONS]
+        )
+        duplicates = {s for s in suffixes if suffixes.count(s) > 1}
+        assert duplicates == set(), (
+            "Duplicate unique_id suffixes: %s" % sorted(duplicates)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -143,63 +193,123 @@ class TestSensorDefinitions:
     def test_no_duplicate_sensor_keys(self):
         assert len(SENSOR_KEYS) == len(set(SENSOR_KEYS))
 
-    def test_sensors_are_read_only(self):
-        """No sensor key should correspond to a writable register entity."""
-        number_keys = {d["key"] for d in NUMBER_DEFINITIONS}
-        select_keys = {d["key"] for d in REGISTER_SELECT_KEYS}
-        controllable = number_keys | select_keys
-        overlap = set(SENSOR_KEYS) & controllable
-        assert overlap == set(), (
-            "These keys are sensors but should be number/select: %s" % overlap
+    def test_every_sensor_has_a_name(self):
+        for defn in SENSOR_DEFINITIONS:
+            assert defn["name"], defn
+
+    def test_no_duplicate_sensor_names(self):
+        names = [d["name"] for d in SENSOR_DEFINITIONS]
+        assert len(names) == len(set(names))
+
+
+# ---------------------------------------------------------------------------
+# Binary sensor
+# ---------------------------------------------------------------------------
+
+class TestBinarySensorDefinitions:
+    def test_no_duplicate_keys(self):
+        assert len(BINARY_SENSOR_KEYS) == len(set(BINARY_SENSOR_KEYS))
+
+    def test_no_duplicate_names(self):
+        names = [d["name"] for d in BINARY_SENSOR_DEFINITIONS]
+        assert len(names) == len(set(names))
+
+    def test_every_system_state_bit_is_exposed(self):
+        """Each named bit of the 32-bit system-state field needs an entity.
+
+        This is the gap the platform was added to close: the integration used
+        to read only register 41 and surface four of the bits.
+        """
+        from fossibot_ha.sydpower.registers import SYSTEM_STATE_BITS
+
+        covered = (
+            set(BINARY_SENSOR_KEYS)
+            | set(SWITCH_KEYS)
+            | set(REGISTER_SWITCH_KEYS)
+        )
+        missing = set(SYSTEM_STATE_BITS.values()) - covered
+        assert missing == set(), (
+            "System-state bits with no entity: %s" % sorted(missing)
         )
 
 
 # ---------------------------------------------------------------------------
-# Switch command completeness
+# Switch
 # ---------------------------------------------------------------------------
 
 class TestSwitchCommands:
     def test_all_switch_commands_in_connector(self):
         for defn in SWITCH_DEFINITIONS:
-            assert defn["on_command"] in CONNECTOR_COMMANDS, (
-                "%s on_command not in COMMANDS" % defn["name"]
+            for field in ("on_command", "off_command"):
+                assert defn[field] in CONNECTOR_COMMANDS, (
+                    "Switch '%s' references unknown command '%s'"
+                    % (defn["key"], defn[field])
+                )
+
+    def test_register_switch_values_are_writable(self):
+        for defn in REGISTER_SWITCH_DEFINITIONS:
+            allowed = WRITABLE_REGISTERS.get(defn["register"])
+            assert allowed is not None, (
+                "Switch '%s' writes register %d, which is not writable"
+                % (defn["key"], defn["register"])
             )
-            assert defn["off_command"] in CONNECTOR_COMMANDS, (
-                "%s off_command not in COMMANDS" % defn["name"]
-            )
+            for field in ("on_value", "off_value"):
+                assert defn[field] in allowed, (
+                    "Switch '%s' %s=%d is not allowed for register %d"
+                    % (defn["key"], field, defn[field], defn["register"])
+                )
 
     def test_no_duplicate_switch_keys(self):
-        keys = [d["key"] for d in SWITCH_DEFINITIONS]
+        keys = SWITCH_KEYS + REGISTER_SWITCH_KEYS
         assert len(keys) == len(set(keys))
 
 
 # ---------------------------------------------------------------------------
-# Select (LED + register-based)
+# Select
 # ---------------------------------------------------------------------------
 
 class TestSelectDefinitions:
-    def test_all_led_commands_in_connector(self):
-        for mode, command in LED_MODES.items():
-            assert command in CONNECTOR_COMMANDS, (
-                "LED mode '%s' → '%s' not in COMMANDS" % (mode, command)
-            )
+    def test_every_select_option_is_writable(self):
+        """Every offered option must be a value the safety map accepts.
 
-    def test_led_mode_count_matches_register(self):
-        assert len(LED_MODES) == len(WRITABLE_REGISTERS[REGISTER_LED])
-
-    def test_register_select_options_match_writable_registers(self):
-        """Each register select should have exactly as many options as
-        allowed values in WRITABLE_REGISTERS."""
-        for defn in REGISTER_SELECT_KEYS:
-            allowed = WRITABLE_REGISTERS[defn["register"]]
-            assert defn["options_count"] == len(allowed), (
-                "Select '%s' has %d options but register allows %d values"
-                % (defn["key"], defn["options_count"], len(allowed))
+        The previous invariant required the option count to equal the number
+        of allowed register values, which no longer holds: the protocol allows
+        a 0~5000 range on the timer registers while the dropdowns offer a
+        handful of useful presets.
+        """
+        for defn in SELECT_DEFINITIONS:
+            allowed = WRITABLE_REGISTERS.get(defn["register"])
+            assert allowed is not None, (
+                "Select '%s' writes register %d, which is not writable"
+                % (defn["key"], defn["register"])
             )
+            for label, value in defn["options"].items():
+                assert value in allowed, (
+                    "Select '%s' option '%s' (%d) is not allowed for "
+                    "register %d" % (defn["key"], label, value, defn["register"])
+                )
+
+    def test_led_mode_covers_every_allowed_value(self):
+        led = next(d for d in SELECT_DEFINITIONS if d["register"] == REGISTER_LED)
+        assert set(led["options"].values()) == set(WRITABLE_REGISTERS[REGISTER_LED])
+
+    def test_led_mode_reads_back_from_the_device(self):
+        """LED mode is set through holding 27 but reported by input 25.
+
+        Reading it back is what lets the select show SOS and Flash; the
+        earlier command-based select had to remember the last choice and
+        could only ever report Off or On.
+        """
+        led = next(d for d in SELECT_DEFINITIONS if d["register"] == REGISTER_LED)
+        assert led["key"] == "lightModeRaw"
 
     def test_no_duplicate_select_keys(self):
-        keys = [d["key"] for d in REGISTER_SELECT_KEYS]
-        assert len(keys) == len(set(keys))
+        assert len(SELECT_KEYS) == len(set(SELECT_KEYS))
+
+    def test_option_values_unique_within_a_select(self):
+        for defn in SELECT_DEFINITIONS:
+            values = list(defn["options"].values())
+            assert len(values) == len(set(values)), defn["key"]
 
 
 # ---------------------------------------------------------------------------
@@ -214,9 +324,44 @@ class TestNumberDefinitions:
                 % (defn["key"], defn["register"])
             )
 
+    def test_number_bounds_are_writable(self):
+        """The slider extremes must encode to values the safety map accepts.
+
+        This is what would have caught the discharge/charge limit sliders
+        offering 0-100% while the protocol documents 0-50% and 60-100%.
+        """
+        for defn in NUMBER_DEFINITIONS:
+            allowed = WRITABLE_REGISTERS[defn["register"]]
+            pack_high = defn.get("pack_high")
+            for bound in ("min_value", "max_value"):
+                raw = int(round(defn[bound] * defn["multiplier"]))
+                if pack_high is not None:
+                    raw = (pack_high << 8) | raw
+                assert raw in allowed, (
+                    "Number '%s' %s=%s encodes to %d, which register %d does "
+                    "not allow"
+                    % (defn["key"], bound, defn[bound], raw, defn["register"])
+                )
+
+    def test_number_step_stays_within_allowed_values(self):
+        """Walking the slider must never produce a rejected value."""
+        for defn in NUMBER_DEFINITIONS:
+            allowed = WRITABLE_REGISTERS[defn["register"]]
+            pack_high = defn.get("pack_high")
+            value = defn["min_value"]
+            while value <= defn["max_value"]:
+                raw = int(round(value * defn["multiplier"]))
+                if pack_high is not None:
+                    raw = (pack_high << 8) | raw
+                assert raw in allowed, (
+                    "Number '%s' value %s encodes to %d, which register %d "
+                    "does not allow"
+                    % (defn["key"], value, raw, defn["register"])
+                )
+                value += defn["step"]
+
     def test_no_duplicate_number_keys(self):
-        keys = [d["key"] for d in NUMBER_DEFINITIONS]
-        assert len(keys) == len(set(keys))
+        assert len(NUMBER_KEYS) == len(set(NUMBER_KEYS))
 
 
 # ---------------------------------------------------------------------------
@@ -228,37 +373,30 @@ class TestWritableRegisterEntityMapping:
 
     @staticmethod
     def _all_entity_registers():
-        """Collect all register IDs that have a controllable entity."""
-        regs = set()
-        # Switches: boolean registers
-        reg_map = {
-            REGISTER_USB_OUTPUT, REGISTER_DC_OUTPUT,
-            REGISTER_AC_OUTPUT, REGISTER_AC_SILENT_CHARGING,
+        regs = {
+            # Command-based switches write these through the connector's
+            # pre-encoded COMMANDS rather than naming a register.
+            REGISTER_USB_OUTPUT,
+            REGISTER_DC_OUTPUT,
+            REGISTER_AC_OUTPUT,
+            REGISTER_AC_SILENT_CHARGING,
         }
-        regs.update(reg_map)
-        # LED select
-        regs.add(REGISTER_LED)
-        # Register-based selects
-        for defn in REGISTER_SELECT_KEYS:
-            regs.add(defn["register"])
-        # Numbers
-        for defn in NUMBER_DEFINITIONS:
-            regs.add(defn["register"])
+        regs.update(d["register"] for d in REGISTER_SWITCH_DEFINITIONS)
+        regs.update(d["register"] for d in SELECT_DEFINITIONS)
+        regs.update(d["register"] for d in NUMBER_DEFINITIONS)
         return regs
 
     def test_every_writable_register_has_entity(self):
-        entity_regs = self._all_entity_registers()
-        writable_regs = set(WRITABLE_REGISTERS.keys())
-        missing = writable_regs - entity_regs
+        missing = set(WRITABLE_REGISTERS) - self._all_entity_registers()
         assert missing == set(), (
-            "Writable registers with no entity: %s" % missing
+            "Writable registers with no entity: %s" % sorted(missing)
         )
 
     def test_boolean_registers_have_switches(self):
-        for reg in [REGISTER_USB_OUTPUT, REGISTER_DC_OUTPUT,
-                    REGISTER_AC_OUTPUT, REGISTER_AC_SILENT_CHARGING]:
+        for reg in (REGISTER_USB_OUTPUT, REGISTER_DC_OUTPUT,
+                    REGISTER_AC_OUTPUT, REGISTER_AC_SILENT_CHARGING):
             assert WRITABLE_REGISTERS[reg] == frozenset({0, 1})
 
-    def test_led_register_has_select(self):
-        switch_keys = {d["key"] for d in SWITCH_DEFINITIONS}
-        assert "ledOutput" not in switch_keys
+    def test_led_register_has_select_not_switch(self):
+        assert "ledOutput" not in SWITCH_KEYS
+        assert REGISTER_LED in {d["register"] for d in SELECT_DEFINITIONS}

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -21,6 +21,9 @@ from fossibot_ha.sydpower.modbus import (
     parse_registers,
     ModbusValidationError,
     WRITABLE_REGISTERS,
+    INTENTIONALLY_NOT_WRITABLE,
+    NOT_SET,
+    pack_byte_pair,
     # Pre-defined commands
     REGRequestSettings,
     REGRequestSensors,
@@ -53,6 +56,13 @@ from fossibot_ha.sydpower.const import (
     REGISTER_DISCHARGE_LIMIT,
     REGISTER_CHARGING_LIMIT,
     REGISTER_SLEEP_TIME,
+    HREG_AC_CHARGE_LEVEL,
+    HREG_APP_CONTROL_SLEEP,
+    HREG_BUZZER,
+    HREG_DC_INPUT_TYPE,
+    HREG_GRID_AC_AUTO_OUTPUT,
+    HREG_LOW_BATTERY_NOTIFY,
+    HREG_WIFI_UPLOAD_INTERVAL,
 )
 
 
@@ -244,22 +254,41 @@ class TestWritableRegisters:
 
     def test_all_expected_registers_present(self):
         expected = {
+            HREG_AC_CHARGE_LEVEL,
+            HREG_DC_INPUT_TYPE,
             REGISTER_MAXIMUM_CHARGING_CURRENT,
             REGISTER_USB_OUTPUT,
             REGISTER_DC_OUTPUT,
             REGISTER_AC_OUTPUT,
             REGISTER_LED,
+            HREG_WIFI_UPLOAD_INTERVAL,
+            HREG_BUZZER,
             REGISTER_AC_SILENT_CHARGING,
             REGISTER_USB_STANDBY_TIME,
             REGISTER_AC_STANDBY_TIME,
             REGISTER_DC_STANDBY_TIME,
             REGISTER_SCREEN_REST_TIME,
-            REGISTER_SLEEP_TIME,
             REGISTER_STOP_CHARGE_AFTER,
+            HREG_APP_CONTROL_SLEEP,
             REGISTER_DISCHARGE_LIMIT,
             REGISTER_CHARGING_LIMIT,
+            REGISTER_SLEEP_TIME,
+            HREG_LOW_BATTERY_NOTIFY,
+            HREG_GRID_AC_AUTO_OUTPUT,
         }
         assert expected == set(WRITABLE_REGISTERS.keys())
+
+    def test_no_register_is_both_writable_and_forbidden(self):
+        overlap = set(WRITABLE_REGISTERS) & set(INTENTIONALLY_NOT_WRITABLE)
+        assert overlap == set(), (
+            "Registers listed as both writable and forbidden: %s" % overlap
+        )
+
+    def test_forbidden_registers_are_refused_with_a_reason(self):
+        for register, reason in INTENTIONALLY_NOT_WRITABLE.items():
+            with pytest.raises(ModbusValidationError, match="refusing to write"):
+                get_write_modbus(REGISTER_MODBUS_ADDRESS, register, 0)
+            assert reason
 
     def test_all_values_are_frozensets(self):
         for reg, allowed in WRITABLE_REGISTERS.items():
@@ -285,34 +314,50 @@ class TestWritableRegisters:
         assert 20 in allowed      # max
         assert 21 not in allowed  # over max
 
-    def test_usb_standby_time(self):
-        assert WRITABLE_REGISTERS[REGISTER_USB_STANDBY_TIME] == frozenset({0, 3, 5, 10, 30})
+    @pytest.mark.parametrize("register", [
+        REGISTER_USB_STANDBY_TIME,
+        REGISTER_AC_STANDBY_TIME,
+        REGISTER_DC_STANDBY_TIME,
+        REGISTER_SCREEN_REST_TIME,
+        REGISTER_STOP_CHARGE_AFTER,
+        REGISTER_SLEEP_TIME,
+    ])
+    def test_timer_registers_use_documented_range(self, register):
+        """Protocol: "Range: 1~5000", with 0 meaning no sleep / disabled."""
+        assert WRITABLE_REGISTERS[register] == frozenset(range(0, 5001))
 
-    def test_ac_standby_time(self):
-        assert WRITABLE_REGISTERS[REGISTER_AC_STANDBY_TIME] == frozenset({0, 480, 960, 1440})
-
-    def test_dc_standby_time(self):
-        assert WRITABLE_REGISTERS[REGISTER_DC_STANDBY_TIME] == frozenset({0, 480, 960, 1440})
-
-    def test_screen_rest_time(self):
-        assert WRITABLE_REGISTERS[REGISTER_SCREEN_REST_TIME] == frozenset({0, 180, 300, 600, 1800})
-
-    def test_sleep_time(self):
-        assert WRITABLE_REGISTERS[REGISTER_SLEEP_TIME] == frozenset({5, 10, 30, 480})
-
-    def test_discharge_limit_boundaries(self):
+    def test_discharge_limit_clamped_to_spec(self):
+        """Holding 66: protocol range 0~500 (0.1%/count) = a 0-50% floor."""
         allowed = WRITABLE_REGISTERS[REGISTER_DISCHARGE_LIMIT]
         assert 0 in allowed
-        assert 1000 in allowed
+        assert 500 in allowed
+        assert 501 not in allowed
+        assert 1000 not in allowed   # a 100% floor is out of spec
         assert -1 not in allowed
+
+    def test_charging_limit_clamped_to_spec(self):
+        """Holding 67: protocol range 600~1000 (0.1%/count) = a 60-100% cap."""
+        allowed = WRITABLE_REGISTERS[REGISTER_CHARGING_LIMIT]
+        assert 600 in allowed
+        assert 1000 in allowed
+        assert 599 not in allowed
+        assert 0 not in allowed      # a 0% ceiling is out of spec
         assert 1001 not in allowed
 
-    def test_charging_limit_boundaries(self):
-        allowed = WRITABLE_REGISTERS[REGISTER_CHARGING_LIMIT]
-        assert 0 in allowed
-        assert 1000 in allowed
-        assert -1 not in allowed
-        assert 1001 not in allowed
+    def test_ac_charge_level_range(self):
+        """Holding 13: protocol "Range: 1-5"."""
+        assert WRITABLE_REGISTERS[HREG_AC_CHARGE_LEVEL] == frozenset(range(1, 6))
+
+    def test_low_battery_notify_packs_two_bytes(self):
+        allowed = WRITABLE_REGISTERS[HREG_LOW_BATTERY_NOTIFY]
+        # Enable on, threshold left untouched.
+        assert pack_byte_pair(1, NOT_SET) in allowed
+        # Threshold 20%, enable left untouched.
+        assert pack_byte_pair(NOT_SET, 20) in allowed
+        # A threshold above 100% is not a valid percentage.
+        assert pack_byte_pair(NOT_SET, 101) not in allowed
+        # An enable byte other than 0/1/0xFF is undefined.
+        assert pack_byte_pair(2, 20) not in allowed
 
 
 # ---------------------------------------------------------------------------
@@ -368,12 +413,26 @@ class TestWriteValidation:
         with pytest.raises(ModbusValidationError):
             get_write_modbus(REGISTER_MODBUS_ADDRESS, REGISTER_LED, 4)
 
-    def test_usb_standby_invalid_raises(self):
+    def test_usb_standby_above_range_raises(self):
         with pytest.raises(ModbusValidationError):
             get_write_modbus(
                 REGISTER_MODBUS_ADDRESS,
                 REGISTER_USB_STANDBY_TIME,
-                7,  # not in {0, 3, 5, 10, 30}
+                5001,  # protocol range is 1~5000, plus 0 for "no sleep"
+            )
+
+    def test_discharge_limit_above_spec_raises(self):
+        """A 100% discharge floor used to be accepted; holding 66 caps at 500."""
+        with pytest.raises(ModbusValidationError):
+            get_write_modbus(
+                REGISTER_MODBUS_ADDRESS, REGISTER_DISCHARGE_LIMIT, 1000,
+            )
+
+    def test_charging_limit_below_spec_raises(self):
+        """A sub-60% charge ceiling used to be accepted; holding 67 starts at 600."""
+        with pytest.raises(ModbusValidationError):
+            get_write_modbus(
+                REGISTER_MODBUS_ADDRESS, REGISTER_CHARGING_LIMIT, 500,
             )
 
     def test_negative_value_raises(self):
@@ -520,11 +579,15 @@ class TestParseRegisters:
         result = parse_registers(regs, "device/response/client/data")
         assert result["acSilentCharging"] is False
 
-    def test_partial_update_soc_only(self):
-        regs = self._make_registers(length=57, overrides={56: 500})
+    def test_partial_response_decodes_what_it_contains(self):
+        """Decoding is index-driven, so a short response yields every register
+        it actually carries instead of collapsing to SOC only."""
+        regs = self._make_registers(length=57, overrides={6: 300, 56: 500})
         result = parse_registers(regs, "device/response/client/04")
         assert result["soc"] == 50.0
-        assert "totalInput" not in result  # not a full 81-register update
+        assert result["totalInput"] == 300
+        # Register 60 is past the end of this response and must stay absent.
+        assert "pvEnergyTotal" not in result
 
     def test_partial_update_with_slaves(self):
         regs = self._make_registers(length=60, overrides={53: 700, 55: 0, 56: 500})


### PR DESCRIPTION
The Sydpower technical team shared their complete Modbus protocol documentation, so the register map no longer has to be inferred from app behaviour. This audits the integration against it and fixes what was wrong.

Full write-up with register citations: [`docs/PROTOCOL_AUDIT.md`](docs/PROTOCOL_AUDIT.md).

## Defects fixed

| | |
|---|---|
| **Both SOC limits accepted out-of-spec writes** | Holding 66 is documented `0~500` (0-50%) and holding 67 `600~1000` (60-100%); the allowlist permitted 0-100% for both — on firmware that does not validate writes and where a bad value bricks the unit |
| **Grid frequency read ~100× low** | Input 22 is 0.1 Hz like input 19, but the two were scaled differently. `decode_frequency()` now picks the scale from magnitude, which cannot be ambiguous for 50/60 Hz mains |
| **Half the system-state field was unreachable** | Inputs 41+42 are one 32-bit word. Register 42 was never read, hiding every port bit, ECO mode and the 12 V outputs |
| **No fault reporting at all** | Eight AC/PV/BMS/panel fault words were arriving and being discarded |
| **LED mode could not be read back** | The select cached its last choice, so it could never show SOS or Flash and went stale if the mode was changed on the unit |
| **Holding 20 mislabelled as AC** | It is the DC (solar/vehicle) charging current. Renamed; `unique_id` unchanged so automations keep working |
| **The device's own current limit was never read** | Holding 17 bounds holding 20 per the spec; that constraint went unenforced |
| **Parsing was locked to `len == 81`** | Any device whose API `modbus_count` differed would silently lose every sensor but SOC |
| **`EntityCategory` imported from a legacy alias** | `homeassistant.helpers.entity` instead of `homeassistant.const` — would break module import, i.e. every platform, on a version where the alias is gone |

Bits the protocol marks *"do not parse"* are excluded from the fault lists — in the BMS words those carry normal operating state (MOSFET closed, charging, balancing) and would have raised a permanent false alarm.

## Added

Registers that were already being polled every cycle and thrown away: a new `binary_sensor` platform for the state field, ~30 sensors, 4 switches, 3 selects, 2 numbers, and device identity (model, per-board hardware/software versions, serial number) in the device registry.

**25 → 107 entity definitions, 55 enabled by default** — per-port breakdowns and BMS internals ship disabled so a device page is not buried under two dozen mostly-zero readings.

Registers left deliberately unwritable (factory reset, debug mode, chip-type selector, timezone) are recorded in `INTENTIONALLY_NOT_WRITABLE` with reasons and asserted to be refused, so omission is a decision rather than an oversight.

## Tests

The suite imported hand-written copies of the entity tables, which had drifted out of sync with the code they were meant to protect. `conftest.py` now stubs Home Assistant as real classes (the platform modules subclass them) so the tests import the live tables. Every number slider is walked from min to max asserting each step encodes to an allowed value — the check that would have caught the SOC sliders.

101 tests pass; pyflakes and `compileall` clean.

## Breaking change

**Discharge Lower Limit is now 0-50% and AC Charging Upper Limit 60-100%**, matching the specification. Values outside those ranges are refused. Version bumped to **3.0.0**; `readme.md` has an "Upgrading to v3.0" section.

## Not verified on hardware

- Whether devices populate input register 42 — the code degrades safely if not (low-half bits read off).
- Serial-number byte order. The document numbers the bytes SN 16 down to SN 1, which does not by itself say which end of the string SN 16 is; `decode_serial` carries a note saying to reverse it if a serial reads backwards against the label on the case.

## Also

- `.claude-flow/` was sitting **inside** `custom_components/fossibot-ha/`, so it would have shipped in the HACS release zip. Added to `.gitignore` along with `custom_components/*.zip`.
- Repo URLs in the readme and manifest pointed at `iamslan/fossibot`, which only resolves through a rename redirect. Updated to the canonical `iamslan/ha-fossibot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
